### PR TITLE
性能优化：修复 UI 卡顿问题

### DIFF
--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/MainActivity.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/MainActivity.kt
@@ -7,6 +7,14 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -57,6 +65,31 @@ class MainActivity : AppCompatActivity() {
 fun AppNavigation() {
     val navController = rememberNavController()
 
+    val depthEnterTransition: androidx.compose.animation.AnimatedContentTransitionScope<androidx.navigation.NavBackStackEntry>.() -> EnterTransition = {
+        slideInVertically(
+            initialOffsetY = { fullHeight -> fullHeight / 5 },
+            animationSpec = tween(durationMillis = 380, easing = FastOutSlowInEasing)
+        ) + fadeIn(animationSpec = tween(280, delayMillis = 60)) +
+            scaleIn(initialScale = 0.96f, animationSpec = tween(380, easing = FastOutSlowInEasing))
+    }
+
+    val depthExitTransition: androidx.compose.animation.AnimatedContentTransitionScope<androidx.navigation.NavBackStackEntry>.() -> ExitTransition = {
+        fadeOut(animationSpec = tween(220)) +
+            scaleOut(targetScale = 0.93f, animationSpec = tween(320, easing = FastOutSlowInEasing))
+    }
+
+    val depthPopEnterTransition: androidx.compose.animation.AnimatedContentTransitionScope<androidx.navigation.NavBackStackEntry>.() -> EnterTransition = {
+        fadeIn(animationSpec = tween(260)) +
+            scaleIn(initialScale = 0.93f, animationSpec = tween(320, easing = FastOutSlowInEasing))
+    }
+
+    val depthPopExitTransition: androidx.compose.animation.AnimatedContentTransitionScope<androidx.navigation.NavBackStackEntry>.() -> ExitTransition = {
+        slideOutVertically(
+            targetOffsetY = { fullHeight -> fullHeight / 4 },
+            animationSpec = tween(durationMillis = 340, easing = FastOutSlowInEasing)
+        ) + fadeOut(animationSpec = tween(260))
+    }
+
     NavHost(
         navController = navController,
         startDestination = Screen.CourseSchedule.route,
@@ -94,29 +127,29 @@ fun AppNavigation() {
         // 所有子页面的转场也都是瞬间完成的
         composable(
             Screen.TimeSlotSettings.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             TimeSlotManagementScreen(onBackClick = { navController.popBackStack() })
         }
         composable(
             Screen.ManageCourseTables.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             ManageCourseTablesScreen(navController = navController)
         }
         // 学校选择
         composable(
             Screen.SchoolSelectionListScreen.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             SchoolSelectionListScreen(navController = navController)
         }
@@ -129,10 +162,10 @@ fun AppNavigation() {
                 navArgument("categoryNumber") { type = NavType.IntType },
                 navArgument("resourceFolder") { type = NavType.StringType }
             ),
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) { backStackEntry ->
             val schoolId = backStackEntry.arguments?.getString("schoolId") ?: ""
             val schoolName = backStackEntry.arguments?.getString("schoolName") ?: "未知学校"
@@ -153,10 +186,10 @@ fun AppNavigation() {
                 navArgument("initialUrl") { type = NavType.StringType },
                 navArgument("assetJsPath") { type = NavType.StringType }
             ),
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) { backStackEntry ->
             val initialUrl = backStackEntry.arguments?.getString("initialUrl")
             val assetJsPath = backStackEntry.arguments?.getString("assetJsPath")
@@ -178,10 +211,10 @@ fun AppNavigation() {
         }
         composable(
             Screen.NotificationSettings.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             NotificationSettingsScreen(onNavigateBack = { navController.popBackStack() })
         }
@@ -193,10 +226,10 @@ fun AppNavigation() {
                     nullable = true
                 }
             ),
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) { backStackEntry ->
             val courseId = backStackEntry.arguments?.getString("courseId")
 
@@ -208,74 +241,74 @@ fun AppNavigation() {
         }
         composable(
             Screen.CourseTableConversion.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             CourseTableConversionScreen(navController = navController)
         }
         composable(
             Screen.MoreOptions.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             MoreOptionsScreen(navController = navController)
         }
         composable(
             Screen.OpenSourceLicenses.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             OpenSourceLicensesScreen (navController = navController)
         }
         composable(
             Screen.UpdateRepo.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             UpdateRepoScreen(navController = navController)
         }
         composable(
             Screen.QuickActions.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             QuickActionsScreen(navController = navController)
         }
         composable(
             Screen.TweakSchedule.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             TweakScheduleScreen(navController = navController)
         }
         composable(
             Screen.ContributionList.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             ContributionScreen(navController = navController)
         }
         // 课程管理 - 一级页面：课程名称列表
         composable(
             Screen.CourseManagementList.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             // CourseNameListScreen 负责显示不重复的课程名称
             CourseNameListScreen(navController = navController)
@@ -287,10 +320,10 @@ fun AppNavigation() {
             arguments = listOf(
                 navArgument(COURSE_NAME_ARG) { type = NavType.StringType }
             ),
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) { backStackEntry ->
             val courseName = Uri.decode(backStackEntry.arguments?.getString(COURSE_NAME_ARG) ?: "")
             CourseInstanceListScreen(
@@ -302,20 +335,20 @@ fun AppNavigation() {
         // 外观定制页面
         composable(
             Screen.StyleSettings.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             StyleSettingsScreen(navController = navController)
         }
         // 快速删除课程页面
         composable(
             Screen.QuickDelete.route,
-            enterTransition = { EnterTransition.None },
-            exitTransition = { ExitTransition.None },
-            popEnterTransition = { EnterTransition.None },
-            popExitTransition = { ExitTransition.None }
+            enterTransition = depthEnterTransition,
+            exitTransition = depthExitTransition,
+            popEnterTransition = depthPopEnterTransition,
+            popExitTransition = depthPopExitTransition
         ) {
             QuickDeleteScreen(navController = navController)
         }

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/db/main/Course.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/db/main/Course.kt
@@ -36,5 +36,12 @@ data class Course(
     val customStartTime: String?, // 自定义起始时间，格式为 "HH:MM"
     val customEndTime: String?,   // 自定义结束时间，格式为 "HH:MM"
 
-    val colorInt: Int // 课程卡片的颜色索引
-)
+    val colorInt: Int, // 课程卡片的颜色索引
+    val weekType: Int = WEEK_TYPE_ALL // 0=每周, 1=单周, 2=双周
+) {
+    companion object {
+        const val WEEK_TYPE_ALL = 0
+        const val WEEK_TYPE_ODD = 1
+        const val WEEK_TYPE_EVEN = 2
+    }
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/db/main/DatabaseMigrations.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/db/main/DatabaseMigrations.kt
@@ -155,9 +155,20 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
     }
 }
 
+/**
+ * 数据库版本 3 迁移到 版本 4 的迁移代码。
+ * 为 courses 表增加单双周类型字段。
+ */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE courses ADD COLUMN weekType INTEGER NOT NULL DEFAULT 0")
+    }
+}
+
 
 // 【集中管理所有迁移对象】
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
+    MIGRATION_3_4,
 )

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/db/main/MainAppDatabase.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/db/main/MainAppDatabase.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
         AppSettings::class,
         CourseTableConfig::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/repository/CourseConversionRepository.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/repository/CourseConversionRepository.kt
@@ -76,7 +76,8 @@ class CourseConversionRepository(
                     isCustomTime = jsonCourse.isCustomTime,
                     customStartTime = jsonCourse.customStartTime,
                     customEndTime = jsonCourse.customEndTime,
-                    colorInt = courseIndex
+                    colorInt = courseIndex,
+                    weekType = jsonCourse.weekType
                 )
             )
 
@@ -126,7 +127,8 @@ class CourseConversionRepository(
                     isCustomTime = jsonCourse.isCustomTime,
                     customStartTime = jsonCourse.customStartTime,
                     customEndTime = jsonCourse.customEndTime,
-                    colorInt = courseIndex
+                    colorInt = courseIndex,
+                    weekType = jsonCourse.weekType
                 )
             )
 
@@ -227,7 +229,8 @@ class CourseConversionRepository(
                 weeks = weeks,
                 isCustomTime = course.isCustomTime,
                 customStartTime = course.customStartTime,
-                customEndTime = course.customEndTime
+                customEndTime = course.customEndTime,
+                weekType = course.weekType
             )
         }
 

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/repository/CourseImportExport.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/repository/CourseImportExport.kt
@@ -38,7 +38,8 @@ object CourseImportExport {
         val isCustomTime: Boolean = false,
         val customStartTime: String? = null,
         val customEndTime: String? = null,
-        val color: Int? = null
+        val color: Int? = null,
+        val weekType: Int = 0
     )
 
     // 导出时使用的 JSON 模型
@@ -62,7 +63,8 @@ object CourseImportExport {
         val weeks: List<Int>,
         val isCustomTime: Boolean = false,
         val customStartTime: String? = null,
-        val customEndTime: String? = null
+        val customEndTime: String? = null,
+        val weekType: Int = 0
     )
 
     // 导入和导出都通用的时间段模型

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/repository/CourseTableRepository.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/repository/CourseTableRepository.kt
@@ -11,6 +11,7 @@ import com.xingheyuzhuan.shiguangschedule.data.db.main.CourseWeekDao
 import com.xingheyuzhuan.shiguangschedule.data.db.main.CourseWithWeeks
 import com.xingheyuzhuan.shiguangschedule.data.db.main.TimeSlot
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
 import java.time.LocalDate
 import java.util.UUID
@@ -313,8 +314,20 @@ class CourseTableRepository(
             return kotlinx.coroutines.flow.flowOf(emptyList())
         }
 
-        // 3. 调用 DAO 层的精准查询方法（按周次过滤）
+        val isOddWeek = weekNumber % 2 != 0
+
+        // 3. 调用 DAO 层的精准查询方法（按周次过滤），再追加单双周过滤
         return courseDao.getCoursesWithWeeksByTableAndWeek(courseTableId, weekNumber)
+            .map { courses ->
+                courses.filter { cw ->
+                    when (cw.course.weekType) {
+                        Course.WEEK_TYPE_ALL -> true
+                        Course.WEEK_TYPE_ODD -> isOddWeek
+                        Course.WEEK_TYPE_EVEN -> !isOddWeek
+                        else -> true
+                    }
+                }
+            }
     }
 }
 

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleScreen.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleScreen.kt
@@ -53,17 +53,14 @@ fun WeeklyScheduleScreen(
     viewModel: WeeklyScheduleViewModel = viewModel(factory = WeeklyScheduleViewModelFactory)
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val today = LocalDate.now()
+    val today = remember { LocalDate.now() }
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-
     val snackbarMsg = stringResource(id = R.string.snackbar_add_course_after_start)
     val appContext = remember { context.applicationContext }
 
     LaunchedEffect(Unit) {
-        viewModel.setStringProvider { id, args ->
-            appContext.resources.getString(id, *args)
-        }
+        viewModel.setStringProvider { id, args -> appContext.resources.getString(id, *args) }
     }
 
     val pagerState = rememberPagerState(
@@ -88,14 +85,16 @@ fun WeeklyScheduleScreen(
     var showWeekSelector by remember { mutableStateOf(false) }
     var showConflictBottomSheet by remember { mutableStateOf(false) }
     var conflictCoursesToShow by remember { mutableStateOf(emptyList<CourseWithWeeks>()) }
-
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
-    val composedStyle by remember(uiState.style) {
-        derivedStateOf { with(ScheduleGridStyleComposed) { uiState.style.toComposedStyle() } }
+    // 优化：直接使用 remember(key) 即可，不需要额外包裹 derivedStateOf
+    val composedStyle = remember(uiState.style) {
+        with(ScheduleGridStyleComposed) {
+            uiState.style.toComposedStyle()
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -148,7 +147,6 @@ fun WeeklyScheduleScreen(
                 // [预加载] 强制渲染相邻页面，确保滑动时目标页已就绪
                 beyondViewportPageCount = 1
             ) { pageIndex ->
-
                 // 去中心化：每一页根据索引独立计算自己的周一日期
                 val pageMondayDate = remember(pageIndex, uiState.firstDayOfWeek) {
                     val offsetWeeks = (pageIndex - INFINITE_PAGER_CENTER).toLong()
@@ -156,13 +154,15 @@ fun WeeklyScheduleScreen(
                     today.with(TemporalAdjusters.previousOrSame(firstDay)).plusWeeks(offsetWeeks)
                 }
 
+                // 缓存 DateTimeFormatter，避免每页重复创建
+                val dateFormatter = remember { DateTimeFormatter.ofPattern("MM-dd") }
+
                 // 独立日期列表：计算该页显示的日期文本
                 val pageDateStrings = remember(pageMondayDate) {
-                    val formatter = DateTimeFormatter.ofPattern("MM-dd")
-                    (0..6).map { pageMondayDate.plusDays(it.toLong()).format(formatter) }
+                    (0..6).map { pageMondayDate.plusDays(it.toLong()).format(dateFormatter) }
                 }
 
-                // 独立高亮：计算“今天”在该页的位置
+                // 独立高亮：计算"今天"在该页的位置
                 val pageTodayIndex = remember(pageMondayDate) {
                     val weekDates = (0..6).map { pageMondayDate.plusDays(it.toLong()) }
                     weekDates.indexOf(today)
@@ -175,7 +175,7 @@ fun WeeklyScheduleScreen(
                     style = composedStyle,
                     dates = pageDateStrings,
                     timeSlots = uiState.timeSlots,
-                    mergedCourses = pageCourses, // 绑定本页专属数据
+                    mergedCourses = pageCourses,
                     showWeekends = uiState.showWeekends,
                     todayIndex = pageTodayIndex,
                     firstDayOfWeek = uiState.firstDayOfWeek,

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleViewModel.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleViewModel.kt
@@ -49,6 +49,18 @@ data class WeeklyScheduleUiState(
     val pagerMondayDate: LocalDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
 )
 
+/**
+ * 预解析的时间槽数据，避免在 mergeCourses 中重复解析
+ */
+private data class ParsedTimeSlot(
+    val slot: TimeSlot,
+    val startTime: LocalTime,
+    val endTime: LocalTime
+)
+
+/** 全局缓存的 DateTimeFormatter，避免重复创建 */
+private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class WeeklyScheduleViewModel(
     private val appSettingsRepository: AppSettingsRepository,
@@ -91,13 +103,14 @@ class WeeklyScheduleViewModel(
     ) { date, settings, config, slots ->
         val tableId = settings.currentCourseTableId
         if (tableId != null && config != null) {
+            // 预解析时间槽，供窗口内所有周复用
+            val parsedSlots = preParseTimeSlots(slots)
             // 定义窗口日期列表
             val window = listOf(date.minusWeeks(1), date, date.plusWeeks(1))
-
             // 为窗口内的每一周开启数据监听并合并成 Map
             combine(window.map { day ->
                 courseTableRepository.getCoursesWithWeeksByDate(tableId, day, config)
-                    .map { courses -> day.toString() to mergeCourses(courses, slots) }
+                    .map { courses -> day.toString() to mergeCourses(courses, slots, parsedSlots) }
             }) { results -> results.toMap() }
         } else {
             flowOf(emptyMap())
@@ -110,10 +123,16 @@ class WeeklyScheduleViewModel(
         this.stringProvider = provider
     }
 
+    /** 记录上次修复颜色时的 style hashCode，避免重复修复 */
+    private var lastColorFixStyleHash: Int = 0
+
     init {
         viewModelScope.launch {
             val configAndTimeFlow = combine(
-                appSettingsFlow, courseTableConfigFlow, styleFlow, _pagerMondayDate
+                appSettingsFlow,
+                courseTableConfigFlow,
+                styleFlow,
+                _pagerMondayDate
             ) { settings, config, style, mondayDate ->
                 ScheduleConfigPackage(settings, config, style, mondayDate)
             }
@@ -129,22 +148,25 @@ class WeeklyScheduleViewModel(
                     startDateStr = config?.semesterStartDate,
                     firstDayOfWeekInt = firstDayOfWeekInt
                 )
-
                 val weekIndex = appSettingsRepository.getWeekIndexAtDate(
                     targetDate = configPkg.mondayDate,
                     startDateStr = config?.semesterStartDate,
                     firstDayOfWeekInt = firstDayOfWeekInt
                 )
 
-                // 修正颜色（仅针对本周课程做检查以减小负担）
+                // 仅在 style 变化时修正颜色，避免每次 collect 都触发
                 val currentWeekCourses = cache[configPkg.mondayDate.toString()] ?: emptyList()
-                fixInvalidCourseColors(currentWeekCourses.flatMap { it.courses }, configPkg.style)
+                val styleHash = configPkg.style.hashCode()
+                if (styleHash != lastColorFixStyleHash) {
+                    lastColorFixStyleHash = styleHash
+                    fixInvalidCourseColors(currentWeekCourses.flatMap { it.courses }, configPkg.style)
+                }
 
                 WeeklyScheduleUiState(
                     style = configPkg.style,
                     showWeekends = config?.showWeekends ?: false,
                     totalWeeks = totalWeeks,
-                    courseCache = cache, // 注入全量缓存
+                    courseCache = cache,
                     currentMergedCourses = cache[configPkg.mondayDate.toString()] ?: emptyList(),
                     timeSlots = timeSlots,
                     isSemesterSet = startDate != null,
@@ -184,51 +206,60 @@ class WeeklyScheduleViewModel(
     }
 
     /**
-     * 计算逻辑节次位置。支持超出范围吸附及课间吸附。
+     * 预解析时间槽，避免在 mergeCourses 和 timeToLogicalScale 中重复解析
      */
-    private fun timeToLogicalScale(time: LocalTime, timeSlots: List<TimeSlot>): Float {
-        if (timeSlots.isEmpty()) return 1.0f
-        val formatter = DateTimeFormatter.ofPattern("HH:mm")
-        val sortedSlots = timeSlots.sortedBy { it.number }
-
-        val firstSlotEnd = LocalTime.parse(sortedSlots.first().endTime, formatter)
-        val lastSlotStart = LocalTime.parse(sortedSlots.last().startTime, formatter)
-
-        if (!time.isAfter(firstSlotEnd)) return 1.0f
-        if (!time.isBefore(lastSlotStart)) return sortedSlots.last().number.toFloat()
-
-        val currentSlot = sortedSlots.find {
-            val s = LocalTime.parse(it.startTime, formatter)
-            val e = LocalTime.parse(it.endTime, formatter)
-            !time.isBefore(s) && !time.isAfter(e)
+    private fun preParseTimeSlots(timeSlots: List<TimeSlot>): List<ParsedTimeSlot> {
+        return timeSlots.sortedBy { it.number }.map { slot ->
+            ParsedTimeSlot(
+                slot = slot,
+                startTime = LocalTime.parse(slot.startTime, TIME_FORMATTER),
+                endTime = LocalTime.parse(slot.endTime, TIME_FORMATTER)
+            )
         }
-
-        if (currentSlot != null) {
-            val sTime = LocalTime.parse(currentSlot.startTime, formatter)
-            val eTime = LocalTime.parse(currentSlot.endTime, formatter)
-            val duration = ChronoUnit.MINUTES.between(sTime, eTime).coerceAtLeast(1)
-            return currentSlot.number.toFloat() + (ChronoUnit.MINUTES.between(sTime, time).toFloat() / duration)
-        }
-
-        val nextSlot = sortedSlots.find { LocalTime.parse(it.startTime, formatter).isAfter(time) }
-        val prevSlot = sortedSlots.lastOrNull { LocalTime.parse(it.endTime, formatter).isBefore(time) }
-        return nextSlot?.number?.toFloat() ?: (prevSlot?.number?.toFloat()?.plus(1.0f) ?: 1.0f)
     }
 
     /**
-     * 合并并处理课程块
+     * 计算逻辑节次位置。支持超出范围吸附及课间吸附。
+     * 使用预解析的时间槽数据，避免重复创建 DateTimeFormatter 和解析时间字符串。
      */
-    fun mergeCourses(courses: List<CourseWithWeeks>, timeSlots: List<TimeSlot>): List<MergedCourseBlock> {
+    private fun timeToLogicalScale(time: LocalTime, parsedSlots: List<ParsedTimeSlot>): Float {
+        if (parsedSlots.isEmpty()) return 1.0f
+
+        val firstSlotEnd = parsedSlots.first().endTime
+        val lastSlotStart = parsedSlots.last().startTime
+
+        if (!time.isAfter(firstSlotEnd)) return 1.0f
+        if (!time.isBefore(lastSlotStart)) return parsedSlots.last().slot.number.toFloat()
+
+        val currentSlot = parsedSlots.find { !time.isBefore(it.startTime) && !time.isAfter(it.endTime) }
+        if (currentSlot != null) {
+            val duration = ChronoUnit.MINUTES.between(currentSlot.startTime, currentSlot.endTime).coerceAtLeast(1)
+            return currentSlot.slot.number.toFloat() + (ChronoUnit.MINUTES.between(currentSlot.startTime, time).toFloat() / duration)
+        }
+
+        val nextSlot = parsedSlots.find { it.startTime.isAfter(time) }
+        val prevSlot = parsedSlots.lastOrNull { it.endTime.isBefore(time) }
+        return nextSlot?.slot?.number?.toFloat() ?: (prevSlot?.slot?.number?.toFloat()?.plus(1.0f) ?: 1.0f)
+    }
+
+    /**
+     * 合并并处理课程块。
+     * 使用预解析的时间槽数据以提升性能。
+     */
+    fun mergeCourses(
+        courses: List<CourseWithWeeks>,
+        timeSlots: List<TimeSlot>,
+        parsedSlots: List<ParsedTimeSlot> = preParseTimeSlots(timeSlots)
+    ): List<MergedCourseBlock> {
         if (timeSlots.isEmpty()) return emptyList()
-        val formatter = DateTimeFormatter.ofPattern("HH:mm")
 
         val normalized = courses.mapNotNull { cw ->
             try {
                 val c = cw.course
                 var (startScale, endScale) = if (c.isCustomTime) {
-                    val sTime = LocalTime.parse(c.customStartTime ?: return@mapNotNull null, formatter)
-                    val eTime = LocalTime.parse(c.customEndTime ?: return@mapNotNull null, formatter)
-                    timeToLogicalScale(sTime, timeSlots) to timeToLogicalScale(eTime, timeSlots)
+                    val sTime = LocalTime.parse(c.customStartTime ?: return@mapNotNull null, TIME_FORMATTER)
+                    val eTime = LocalTime.parse(c.customEndTime ?: return@mapNotNull null, TIME_FORMATTER)
+                    timeToLogicalScale(sTime, parsedSlots) to timeToLogicalScale(eTime, parsedSlots)
                 } else {
                     val s = c.startSection?.toFloat() ?: return@mapNotNull null
                     val e = c.endSection?.toFloat() ?: return@mapNotNull null

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/CourseBlock.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/CourseBlock.kt
@@ -1,17 +1,17 @@
 package com.xingheyuzhuan.shiguangschedule.ui.schedule.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -74,7 +74,6 @@ fun CourseBlock(
 
     // --- 字体大小计算逻辑 (新增) ---
     // 通过将基准字号乘以缩放因子，实现全局联动
-    val s13 = (13 * style.fontScale).sp
     val s12 = (12 * style.fontScale).sp
     val s10 = (10 * style.fontScale).sp
 
@@ -87,11 +86,19 @@ fun CourseBlock(
     }
     val isCustomTimeCourse = customTimeString != null
 
-    Box(
+    Surface(
         modifier = modifier
             .padding(style.courseBlockOuterPadding)
-            .clip(RoundedCornerShape(style.courseBlockCornerRadius))
-            .background(color = blockColor)
+            .shadow(
+                elevation = 6.dp,
+                shape = RoundedCornerShape(14.dp),
+                ambientColor = Color.Black.copy(alpha = 0.12f),
+                spotColor = Color.Black.copy(alpha = 0.08f)
+            )
+            .clip(RoundedCornerShape(14.dp)),
+        shape = RoundedCornerShape(14.dp),
+        color = blockColor,
+        tonalElevation = 1.dp
     ) {
         Column(
             modifier = Modifier
@@ -141,7 +148,7 @@ fun CourseBlock(
                 // --- 2. 课程名称 ---
                 Text(
                     text = firstCourse?.course?.name ?: "",
-                    fontSize = s13,
+                    fontSize = (14 * style.fontScale).sp,
                     fontWeight = FontWeight.Bold,
                     color = textColor,
                     overflow = TextOverflow.Ellipsis,
@@ -155,7 +162,7 @@ fun CourseBlock(
                     if (teacher.isNotBlank()) {
                         Text(
                             text = teacher,
-                            fontSize = s10,
+                            fontSize = s12,
                             color = textColor,
                             overflow = TextOverflow.Ellipsis,
                             style = TextStyle(lineHeight = 1.em)

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/CourseBlock.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/CourseBlock.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
@@ -35,68 +36,71 @@ fun CourseBlock(
     startTime: String? = null
 ) {
     val firstCourse = mergedBlock.courses.firstOrNull()
-    val isDarkTheme = isSystemInDarkTheme() // 获取当前主题模式
+    val isDarkTheme = isSystemInDarkTheme()
 
-    val conflictColorAdapted = if (isDarkTheme) {
-        style.conflictCourseColorDark // 使用深色冲突色
-    } else {
-        style.conflictCourseColor // 使用浅色冲突色
-    }
-
-    // 尝试获取颜色索引 (colorInt)
-    val colorIndex = firstCourse?.course?.colorInt
-        // 检查索引是否在映射表范围内，否则返回 null
-        ?.takeIf { it in style.courseColorMaps.indices }
-
-    // 适配后的课程颜色，如果 colorIndex 存在
-    val courseColorAdapted: Color? = colorIndex?.let { index ->
-        val baseColorMap = style.courseColorMaps[index]
-        if (isDarkTheme) {
-            baseColorMap.dark
+    // 缓存颜色计算，避免每次重组都重新计算
+    val blockColor = remember(mergedBlock.isConflict, firstCourse?.course?.colorInt, isDarkTheme, style) {
+        val conflictColorAdapted = if (isDarkTheme) {
+            style.conflictCourseColorDark
         } else {
-            baseColorMap.light
+            style.conflictCourseColor
         }
-    }
 
-    val fallbackColorAdapted: Color = if (isDarkTheme) {
-        style.courseColorMaps.first().dark
-    } else {
-        style.courseColorMaps.first().light
-    }
+        val colorIndex = firstCourse?.course?.colorInt
+            ?.takeIf { it in style.courseColorMaps.indices }
 
-    val blockColor = if (mergedBlock.isConflict) {
-        conflictColorAdapted.copy(alpha = style.courseBlockAlpha)
-    } else {
-        (courseColorAdapted ?: fallbackColorAdapted).copy(alpha = style.courseBlockAlpha)
+        val courseColorAdapted: Color? = colorIndex?.let { index ->
+            val baseColorMap = style.courseColorMaps[index]
+            if (isDarkTheme) baseColorMap.dark else baseColorMap.light
+        }
+
+        val fallbackColorAdapted: Color = if (isDarkTheme) {
+            style.courseColorMaps.first().dark
+        } else {
+            style.courseColorMaps.first().light
+        }
+
+        if (mergedBlock.isConflict) {
+            conflictColorAdapted.copy(alpha = style.courseBlockAlpha)
+        } else {
+            (courseColorAdapted ?: fallbackColorAdapted).copy(alpha = style.courseBlockAlpha)
+        }
     }
 
     val textColor = MaterialTheme.colorScheme.onSurface
 
-    // --- 字体大小计算逻辑 (新增) ---
-    // 通过将基准字号乘以缩放因子，实现全局联动
-    val s12 = (12 * style.fontScale).sp
-    val s10 = (10 * style.fontScale).sp
+    // 缓存字体大小计算
+    val s12 = remember(style.fontScale) { (12 * style.fontScale).sp }
+    val s10 = remember(style.fontScale) { (10 * style.fontScale).sp }
+    val s14 = remember(style.fontScale) { (14 * style.fontScale).sp }
 
-    val customStartTime = firstCourse?.course?.customStartTime
-    val customEndTime = firstCourse?.course?.customEndTime
-    val customTimeString = if (customStartTime != null && customEndTime != null) {
-        "$customStartTime - $customEndTime"
-    } else {
-        null
+    // 缓存自定义时间字符串
+    val customTimeString = remember(firstCourse?.course?.customStartTime, firstCourse?.course?.customEndTime) {
+        val customStartTime = firstCourse?.course?.customStartTime
+        val customEndTime = firstCourse?.course?.customEndTime
+        if (customStartTime != null && customEndTime != null) {
+            "$customStartTime - $customEndTime"
+        } else {
+            null
+        }
     }
+
     val isCustomTimeCourse = customTimeString != null
+
+    // 缓存 shape，避免重复创建
+    val blockShape = remember { RoundedCornerShape(14.dp) }
 
     Surface(
         modifier = modifier
             .padding(style.courseBlockOuterPadding)
             .shadow(
                 elevation = 6.dp,
-                shape = RoundedCornerShape(14.dp),
+                shape = blockShape,
                 ambientColor = Color.Black.copy(alpha = 0.12f),
                 spotColor = Color.Black.copy(alpha = 0.08f)
             )
-            .clip(RoundedCornerShape(14.dp)),
-        shape = RoundedCornerShape(14.dp),
+            .clip(blockShape),
+        shape = blockShape,
         color = blockColor,
         tonalElevation = 1.dp
     ) {
@@ -110,7 +114,7 @@ fun CourseBlock(
                 mergedBlock.courses.forEach { course ->
                     Text(
                         text = course.course.name,
-                        fontSize = s12, // 使用缩放后的 12sp
+                        fontSize = s12,
                         fontWeight = FontWeight.Bold,
                         color = textColor,
                         overflow = TextOverflow.Ellipsis,
@@ -119,7 +123,7 @@ fun CourseBlock(
                 }
                 Text(
                     text = stringResource(R.string.label_conflict),
-                    fontSize = s10, // 使用缩放后的 10sp
+                    fontSize = s10,
                     color = textColor,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(top = 2.dp)
@@ -128,8 +132,8 @@ fun CourseBlock(
                 // --- 1. 时间显示层 ---
                 if (isCustomTimeCourse) {
                     Text(
-                        text = customTimeString,
-                        fontSize = s10, // 使用缩放后的 10sp
+                        text = customTimeString!!,
+                        fontSize = s10,
                         color = textColor.copy(alpha = 0.8f),
                         fontWeight = FontWeight.SemiBold,
                         overflow = TextOverflow.Ellipsis,
@@ -138,7 +142,7 @@ fun CourseBlock(
                 } else if (style.showStartTime && startTime != null) {
                     Text(
                         text = startTime,
-                        fontSize = s10, // 使用缩放后的 10sp
+                        fontSize = s10,
                         color = textColor.copy(alpha = 0.8f),
                         fontWeight = FontWeight.SemiBold,
                         style = TextStyle(lineHeight = 1.em)
@@ -148,7 +152,7 @@ fun CourseBlock(
                 // --- 2. 课程名称 ---
                 Text(
                     text = firstCourse?.course?.name ?: "",
-                    fontSize = (14 * style.fontScale).sp,
+                    fontSize = s14,
                     fontWeight = FontWeight.Bold,
                     color = textColor,
                     overflow = TextOverflow.Ellipsis,
@@ -157,7 +161,7 @@ fun CourseBlock(
                 )
 
                 // --- 3. 教师 (受 hideTeacher 开关控制) ---
-                if (!style.hideTeacher) { // 如果不隐藏，则显示
+                if (!style.hideTeacher) {
                     val teacher = firstCourse?.course?.teacher ?: ""
                     if (teacher.isNotBlank()) {
                         Text(
@@ -171,10 +175,9 @@ fun CourseBlock(
                 }
 
                 // --- 4. 地点 (受 hideLocation 和 removeLocationAt 开关控制) ---
-                if (!style.hideLocation) { // 如果不隐藏，则显示
+                if (!style.hideLocation) {
                     val position = firstCourse?.course?.position ?: ""
                     if (position.isNotBlank()) {
-                        // 根据 removeLocationAt 决定前缀
                         val prefix = if (style.removeLocationAt) "" else "@"
                         Text(
                             text = "$prefix$position",

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
@@ -3,6 +3,7 @@ package com.xingheyuzhuan.shiguangschedule.ui.schedule.components
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -18,6 +20,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -65,15 +69,17 @@ fun ScheduleGrid(
         val totalGridHeight = style.sectionHeight * timeSlots.size
         val gridLineColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.08f)
 
-        // 3. 转换绘图数据
-        val schedulables = mergedCourses.mapNotNull { block ->
-            val displayIdx = mapDayToDisplayIndex(block.day, firstDayOfWeek, showWeekends)
-            if (displayIdx == -1) return@mapNotNull null
-            object : ISchedulable {
-                override val columnIndex = displayIdx
-                override val startSection = block.startSection
-                override val endSection = block.endSection
-                override val rawData = block
+        // 3. 转换绘图数据 - 使用 remember 缓存
+        val schedulables = remember(mergedCourses, firstDayOfWeek, showWeekends) {
+            mergedCourses.mapNotNull { block ->
+                val displayIdx = mapDayToDisplayIndex(block.day, firstDayOfWeek, showWeekends)
+                if (displayIdx == -1) return@mapNotNull null
+                object : ISchedulable {
+                    override val columnIndex = displayIdx
+                    override val startSection = block.startSection
+                    override val endSection = block.endSection
+                    override val rawData = block
+                }
             }
         }
 
@@ -84,9 +90,7 @@ fun ScheduleGrid(
                 TimeColumn(style, timeSlots, onTimeSlotClicked, Modifier.height(totalGridHeight), gridLineColor)
 
                 Box(Modifier.height(totalGridHeight).weight(1f)) {
-                    // 控制主体网格线显示
-                    // WakeUp 风格：移除主网格硬线，仅保留课程卡片与顶部/时间轴轻层次
-
+                    // 优化：使用单个手势检测器替代 91 个 Composable
                     ClickableGrid(displayDays.size, timeSlots.size, cellWidth, style.sectionHeight) { dayIdx, sec ->
                         onGridCellClicked(mapDisplayIndexToDay(dayIdx, firstDayOfWeek), sec)
                     }
@@ -119,9 +123,14 @@ fun ScheduleGrid(
 }
 
 // 子组件
-
 @Composable
 private fun DayHeader(style: ScheduleGridStyleComposed, displayDays: List<String>, dates: List<String>, cellWidth: Dp, todayIndex: Int, lineColor: Color) {
+    // 预缓存颜色，避免每次重组重新计算
+    val surfaceColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
+    val primaryContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.48f)
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
+    val onSurfaceVariantColor = MaterialTheme.colorScheme.onSurfaceVariant
+
     Row(
         Modifier
             .fillMaxWidth()
@@ -129,30 +138,31 @@ private fun DayHeader(style: ScheduleGridStyleComposed, displayDays: List<String
             .padding(horizontal = 8.dp)
             .shadow(4.dp, RoundedCornerShape(14.dp), ambientColor = Color.Black.copy(alpha = 0.08f))
             .clip(RoundedCornerShape(14.dp))
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+            .background(surfaceColor)
     ) {
         Spacer(Modifier.width(style.timeColumnWidth).fillMaxHeight())
+
         displayDays.forEachIndexed { index, day ->
             Box(Modifier.width(cellWidth).fillMaxHeight()
-                .background(if (index == todayIndex) MaterialTheme.colorScheme.primaryContainer.copy(0.48f) else Color.Transparent)
+                .background(if (index == todayIndex) primaryContainerColor else Color.Transparent)
                 .drawBehind {
                     if (!style.hideGridLines) {
                         drawLine(lineColor, Offset(size.width, 0f), Offset(size.width, size.height), 1f)
                     }
-                }, contentAlignment = Alignment.Center) {
+                },
+                contentAlignment = Alignment.Center) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    // 统一使用 onSurface，不加高亮判断
                     Text(
                         text = day,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface
+                        color = onSurfaceColor
                     )
                     if (!style.hideDateUnderDay && dates.size > index) {
                         Text(
                             text = dates[index],
                             fontSize = 10.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = onSurfaceVariantColor
                         )
                     }
                 }
@@ -163,42 +173,48 @@ private fun DayHeader(style: ScheduleGridStyleComposed, displayDays: List<String
 
 @Composable
 private fun TimeColumn(style: ScheduleGridStyleComposed, timeSlots: List<TimeSlot>, onTimeSlotClicked: () -> Unit, modifier: Modifier, lineColor: Color) {
+    val surfaceColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.86f)
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
+    val onSurfaceVariantColor = MaterialTheme.colorScheme.onSurfaceVariant
+
     Surface(
         modifier = modifier
             .width(style.timeColumnWidth)
             .padding(start = 6.dp, end = 6.dp, top = 8.dp)
             .shadow(3.dp, RoundedCornerShape(12.dp), ambientColor = Color.Black.copy(alpha = 0.06f))
             .clip(RoundedCornerShape(12.dp)),
-        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.86f),
+        color = surfaceColor,
         shape = RoundedCornerShape(12.dp)
     ) {
         Column {
-        timeSlots.forEach { slot ->
-            Column(Modifier.fillMaxWidth().height(style.sectionHeight).clickable { onTimeSlotClicked() }.drawBehind {
-                if (!style.hideGridLines) {
-                    drawLine(lineColor, Offset(0f, size.height), Offset(size.width, size.height), 1f)
-                }
-            }, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
-                Text(
-                    text = slot.number.toString(),
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                if (!style.hideSectionTime) {
+            timeSlots.forEach { slot ->
+                Column(Modifier.fillMaxWidth().height(style.sectionHeight).clickable { onTimeSlotClicked() }.drawBehind {
+                    if (!style.hideGridLines) {
+                        drawLine(lineColor, Offset(0f, size.height), Offset(size.width, size.height), 1f)
+                    }
+                },
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center) {
                     Text(
-                        text = slot.startTime,
-                        fontSize = 10.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = slot.number.toString(),
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = onSurfaceColor
                     )
-                    Text(
-                        text = slot.endTime,
-                        fontSize = 10.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    if (!style.hideSectionTime) {
+                        Text(
+                            text = slot.startTime,
+                            fontSize = 10.sp,
+                            color = onSurfaceVariantColor
+                        )
+                        Text(
+                            text = slot.endTime,
+                            fontSize = 10.sp,
+                            color = onSurfaceVariantColor
+                        )
+                    }
                 }
             }
-        }
         }
     }
 }
@@ -218,21 +234,30 @@ private fun GridLines(dayCount: Int, slotCount: Int, cellWidth: Dp, totalHeight:
     }
 }
 
+/**
+ * 优化：使用单个 pointerInput 手势检测替代 Column + Row + Spacer 创建的 91 个 Composable。
+ * 从 O(dayCount * slotCount) 个 Composable 减少到 1 个，大幅降低重组开销。
+ */
 @Composable
 private fun ClickableGrid(dayCount: Int, slotCount: Int, cellWidth: Dp, sectionHeight: Dp, onClick: (Int, Int) -> Unit) {
-    Column(Modifier.fillMaxSize()) {
-        for (sec in 1..slotCount) {
-            Row(Modifier.fillMaxWidth().height(sectionHeight)) {
-                repeat(dayCount) { idx ->
-                    Spacer(Modifier.width(cellWidth).fillMaxHeight().clickable { onClick(idx, sec) })
+    val density = LocalDensity.current
+    val cellWidthPx = with(density) { cellWidth.toPx() }
+    val sectionHeightPx = with(density) { sectionHeight.toPx() }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(dayCount, slotCount, cellWidthPx, sectionHeightPx) {
+                detectTapGestures { offset ->
+                    val dayIdx = (offset.x / cellWidthPx).toInt().coerceIn(0, dayCount - 1)
+                    val sec = (offset.y / sectionHeightPx).toInt().coerceIn(0, slotCount - 1) + 1
+                    onClick(dayIdx, sec)
                 }
             }
-        }
-    }
+    )
 }
 
-//  辅助逻辑
-
+// 辅助逻辑
 private fun rearrangeDays(originalDays: List<String>, firstDayOfWeek: Int): List<String> {
     val startIndex = (firstDayOfWeek - 1).coerceIn(0, 6)
     return originalDays.subList(startIndex, originalDays.size) + originalDays.subList(0, startIndex)

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
@@ -5,13 +5,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringArrayResource
@@ -59,7 +63,7 @@ fun ScheduleGrid(
         // 2. 计算尺寸
         val cellWidth = (screenWidth - style.timeColumnWidth) / displayDays.size
         val totalGridHeight = style.sectionHeight * timeSlots.size
-        val gridLineColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+        val gridLineColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.08f)
 
         // 3. 转换绘图数据
         val schedulables = mergedCourses.mapNotNull { block ->
@@ -81,9 +85,7 @@ fun ScheduleGrid(
 
                 Box(Modifier.height(totalGridHeight).weight(1f)) {
                     // 控制主体网格线显示
-                    if (!style.hideGridLines) {
-                        GridLines(displayDays.size, timeSlots.size, cellWidth, totalGridHeight, style.sectionHeight, gridLineColor)
-                    }
+                    // WakeUp 风格：移除主网格硬线，仅保留课程卡片与顶部/时间轴轻层次
 
                     ClickableGrid(displayDays.size, timeSlots.size, cellWidth, style.sectionHeight) { dayIdx, sec ->
                         onGridCellClicked(mapDisplayIndexToDay(dayIdx, firstDayOfWeek), sec)
@@ -120,21 +122,19 @@ fun ScheduleGrid(
 
 @Composable
 private fun DayHeader(style: ScheduleGridStyleComposed, displayDays: List<String>, dates: List<String>, cellWidth: Dp, todayIndex: Int, lineColor: Color) {
-    Row(Modifier.fillMaxWidth().height(style.dayHeaderHeight).drawBehind {
-        // 表头底部横线
-        if (!style.hideGridLines) {
-            drawLine(lineColor, Offset(0f, size.height), Offset(size.width, size.height), 1f)
-        }
-    }) {
-        Spacer(Modifier.width(style.timeColumnWidth).fillMaxHeight().drawBehind {
-            // 时间轴右侧分割线
-            if (!style.hideGridLines) {
-                drawLine(lineColor, Offset(size.width, 0f), Offset(size.width, size.height), 1f)
-            }
-        })
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .height(style.dayHeaderHeight)
+            .padding(horizontal = 8.dp)
+            .shadow(4.dp, RoundedCornerShape(14.dp), ambientColor = Color.Black.copy(alpha = 0.08f))
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+    ) {
+        Spacer(Modifier.width(style.timeColumnWidth).fillMaxHeight())
         displayDays.forEachIndexed { index, day ->
             Box(Modifier.width(cellWidth).fillMaxHeight()
-                .background(if (index == todayIndex) MaterialTheme.colorScheme.primaryContainer.copy(0.4f) else Color.Transparent)
+                .background(if (index == todayIndex) MaterialTheme.colorScheme.primaryContainer.copy(0.48f) else Color.Transparent)
                 .drawBehind {
                     if (!style.hideGridLines) {
                         drawLine(lineColor, Offset(size.width, 0f), Offset(size.width, size.height), 1f)
@@ -163,11 +163,16 @@ private fun DayHeader(style: ScheduleGridStyleComposed, displayDays: List<String
 
 @Composable
 private fun TimeColumn(style: ScheduleGridStyleComposed, timeSlots: List<TimeSlot>, onTimeSlotClicked: () -> Unit, modifier: Modifier, lineColor: Color) {
-    Column(modifier.width(style.timeColumnWidth).drawBehind {
-        if (!style.hideGridLines) {
-            drawLine(lineColor, Offset(size.width, 0f), Offset(size.width, size.height), 1f)
-        }
-    }) {
+    Surface(
+        modifier = modifier
+            .width(style.timeColumnWidth)
+            .padding(start = 6.dp, end = 6.dp, top = 8.dp)
+            .shadow(3.dp, RoundedCornerShape(12.dp), ambientColor = Color.Black.copy(alpha = 0.06f))
+            .clip(RoundedCornerShape(12.dp)),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.86f),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column {
         timeSlots.forEach { slot ->
             Column(Modifier.fillMaxWidth().height(style.sectionHeight).clickable { onTimeSlotClicked() }.drawBehind {
                 if (!style.hideGridLines) {
@@ -193,6 +198,7 @@ private fun TimeColumn(style: ScheduleGridStyleComposed, timeSlots: List<TimeSlo
                     )
                 }
             }
+        }
         }
     }
 }

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/settings/course/AddEditCourseScreen.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/settings/course/AddEditCourseScreen.kt
@@ -168,6 +168,11 @@ fun AddEditCourseScreen(
                 onWeekClick = { showWeekSelectorDialog = true }
             )
 
+            WeekTypeSelector(
+                selectedWeekType = uiState.weekType,
+                onWeekTypeSelected = viewModel::onWeekTypeChange
+            )
+
             ColorPicker(
                 selectedColor = uiState.courseColorMaps.getOrNull(uiState.colorIndex)?.let { dualColor ->
                     if (isDarkTheme) dualColor.dark else dualColor.light

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/settings/course/AddEditCourseViewModel.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/settings/course/AddEditCourseViewModel.kt
@@ -116,7 +116,8 @@ class AddEditCourseViewModel(
                             isCustomTime = false,
                             customStartTime = null,
                             customEndTime = null,
-                            colorInt = newColorIndex
+                            colorInt = newColorIndex,
+                            weekType = Course.WEEK_TYPE_ALL
                         )
                         Pair(newCourse, newColorIndex)
                     } else {
@@ -156,6 +157,7 @@ class AddEditCourseViewModel(
                         customStartTime = course?.customStartTime.orEmpty(),
                         customEndTime = course?.customEndTime.orEmpty(),
                         colorIndex = initialColorIndex,
+                        weekType = course?.weekType ?: Course.WEEK_TYPE_ALL,
                         weeks = weeks,
                         timeSlots = timeSlots,
                         currentCourseTableId = appSettings.currentCourseTableId,
@@ -175,6 +177,7 @@ class AddEditCourseViewModel(
     fun onEndSectionChange(endSection: Int) { _uiState.update { it.copy(endSection = endSection) } }
     fun onWeeksChange(newWeeks: Set<Int>) { _uiState.update { it.copy(weeks = newWeeks) } }
     fun onColorChange(colorIndex: Int) { _uiState.update { it.copy(colorIndex = colorIndex) } }
+    fun onWeekTypeChange(weekType: Int) { _uiState.update { it.copy(weekType = weekType) } }
     fun onIsCustomTimeChange(isCustom: Boolean) { _uiState.update { it.copy(isCustomTime = isCustom) } }
 
     fun onCustomTimeChange(startTime: String, endTime: String) {
@@ -200,6 +203,7 @@ class AddEditCourseViewModel(
                 customStartTime = state.customStartTime.takeIf { state.isCustomTime && it.isNotEmpty() },
                 customEndTime = state.customEndTime.takeIf { state.isCustomTime && it.isNotEmpty() },
                 colorInt = state.colorIndex,
+                weekType = state.weekType,
                 courseTableId = state.currentCourseTableId.orEmpty()
             )
             if (courseToSave != null) {
@@ -264,6 +268,7 @@ data class AddEditCourseUiState(
     val customStartTime: String = "",
     val customEndTime: String = "",
     val colorIndex: Int = 0,
+    val weekType: Int = Course.WEEK_TYPE_ALL,
     val weeks: Set<Int> = emptySet(),
     val timeSlots: List<TimeSlot> = emptyList(),
     val currentCourseTableId: String? = null,

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/settings/course/CourseOtherSelectors.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/settings/course/CourseOtherSelectors.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.xingheyuzhuan.shiguangschedule.R
+import com.xingheyuzhuan.shiguangschedule.data.db.main.Course
 import com.xingheyuzhuan.shiguangschedule.data.model.DualColor
 import kotlinx.coroutines.launch
 
@@ -212,6 +213,44 @@ fun ColorPicker(
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WeekTypeSelector(
+    selectedWeekType: Int,
+    onWeekTypeSelected: (Int) -> Unit
+) {
+    val label = stringResource(R.string.label_week_type)
+    val everyWeek = stringResource(R.string.week_type_every_week)
+    val oddWeek = stringResource(R.string.action_single_week)
+    val evenWeek = stringResource(R.string.action_double_week)
+
+    val options = listOf(
+        CourseWeekTypeOption(Course.WEEK_TYPE_ALL, everyWeek),
+        CourseWeekTypeOption(Course.WEEK_TYPE_ODD, oddWeek),
+        CourseWeekTypeOption(Course.WEEK_TYPE_EVEN, evenWeek)
+    )
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = label, style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, option ->
+                SegmentedButton(
+                    selected = selectedWeekType == option.value,
+                    onClick = { onWeekTypeSelected(option.value) },
+                    shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                    label = { Text(option.label) }
+                )
+            }
+        }
+    }
+}
+
+private data class CourseWeekTypeOption(
+    val value: Int,
+    val label: String
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/theme/Color.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/theme/Color.kt
@@ -2,10 +2,22 @@ package com.xingheyuzhuan.shiguangschedule.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// WakeUp 风格：低饱和柔和配色
+val WakeupBlue = Color(0xFF8FB8FF)
+val WakeupBlueContainer = Color(0xFFDDE9FF)
+val WakeupPink = Color(0xFFF4AFC8)
+val WakeupPinkContainer = Color(0xFFFFE3EE)
+val WakeupGreen = Color(0xFF9FD6B5)
+val WakeupGreenContainer = Color(0xFFE2F5EA)
+val WakeupYellow = Color(0xFFF4D68A)
+val WakeupYellowContainer = Color(0xFFFFF3D6)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val WakeupBackgroundLight = Color(0xFFF6F8FC)
+val WakeupSurfaceLight = Color(0xFFFFFFFF)
+val WakeupOnSurfaceLight = Color(0xFF1F2937)
+val WakeupOnSurfaceVariantLight = Color(0xFF6B7280)
+
+val WakeupBackgroundDark = Color(0xFF141822)
+val WakeupSurfaceDark = Color(0xFF1B2230)
+val WakeupOnSurfaceDark = Color(0xFFE8ECF5)
+val WakeupOnSurfaceVariantDark = Color(0xFFA2AEBD)

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/theme/Theme.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/theme/Theme.kt
@@ -14,29 +14,43 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80,
-    background = Color(0xFF1C1B1F),
-    surface = Color(0xFF1C1B1F),
-    onBackground = Color.White,
-    onSurface = Color.White
+    primary = WakeupBlue,
+    onPrimary = Color.White,
+    primaryContainer = WakeupBlueContainer.copy(alpha = 0.28f),
+    secondary = WakeupPink,
+    secondaryContainer = WakeupPinkContainer.copy(alpha = 0.22f),
+    tertiary = WakeupGreen,
+    tertiaryContainer = WakeupGreenContainer.copy(alpha = 0.2f),
+    background = WakeupBackgroundDark,
+    surface = WakeupSurfaceDark,
+    onBackground = WakeupOnSurfaceDark,
+    onSurface = WakeupOnSurfaceDark,
+    onSurfaceVariant = WakeupOnSurfaceVariantDark,
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
+    primary = WakeupBlue,
+    onPrimary = Color.White,
+    primaryContainer = WakeupBlueContainer,
+    secondary = WakeupPink,
+    secondaryContainer = WakeupPinkContainer,
+    tertiary = WakeupGreen,
+    tertiaryContainer = WakeupGreenContainer,
+    background = WakeupBackgroundLight,
+    surface = WakeupSurfaceLight,
+    onBackground = WakeupOnSurfaceLight,
+    onSurface = WakeupOnSurfaceLight,
+    onSurfaceVariant = WakeupOnSurfaceVariantLight,
 )
 
 @Composable
 fun ShiguangScheduleTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
@@ -60,6 +74,8 @@ fun ShiguangScheduleTheme(
             window.statusBarColor = Color.Transparent.toArgb()
             @Suppress("DEPRECATION")
             window.navigationBarColor = Color.Transparent.toArgb()
+
+            WindowCompat.setDecorFitsSystemWindows(window, false)
             val insetsController = WindowCompat.getInsetsController(window, view)
             insetsController.isAppearanceLightStatusBars = !darkTheme
             insetsController.isAppearanceLightNavigationBars = !darkTheme

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/transition/ActivityDepthTransition.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/transition/ActivityDepthTransition.kt
@@ -1,0 +1,15 @@
+package com.xingheyuzhuan.shiguangschedule.ui.transition
+
+import android.app.Activity
+import com.xingheyuzhuan.shiguangschedule.R
+
+/**
+ * Activity 场景下的景深转场（用于 overridePendingTransition）。
+ */
+fun Activity.applyDepthOpenTransition() {
+    overridePendingTransition(R.anim.slide_in_up, R.anim.scale_down_back)
+}
+
+fun Activity.applyDepthCloseTransition() {
+    overridePendingTransition(R.anim.scale_restore_front, R.anim.slide_out_down)
+}

--- a/app/src/main/res/anim/scale_down_back.xml
+++ b/app/src/main/res/anim/scale_down_back.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="true"
+    android:fillAfter="true">
+
+    <scale
+        android:duration="320"
+        android:fromXScale="1.0"
+        android:fromYScale="1.0"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="0.93"
+        android:toYScale="0.93" />
+
+    <alpha
+        android:duration="320"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.86" />
+</set>

--- a/app/src/main/res/anim/scale_restore_front.xml
+++ b/app/src/main/res/anim/scale_restore_front.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="true">
+
+    <scale
+        android:duration="320"
+        android:fromXScale="0.93"
+        android:fromYScale="0.93"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="1.0"
+        android:toYScale="1.0" />
+
+    <alpha
+        android:duration="320"
+        android:fromAlpha="0.86"
+        android:toAlpha="1.0" />
+</set>

--- a/app/src/main/res/anim/slide_in_up.xml
+++ b/app/src/main/res/anim/slide_in_up.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="true">
+
+    <translate
+        android:duration="360"
+        android:fromYDelta="100%p"
+        android:interpolator="@android:interpolator/fast_out_slow_in"
+        android:toYDelta="0%p" />
+
+    <alpha
+        android:duration="300"
+        android:fromAlpha="0.92"
+        android:toAlpha="1.0" />
+</set>

--- a/app/src/main/res/anim/slide_out_down.xml
+++ b/app/src/main/res/anim/slide_out_down.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="true">
+
+    <translate
+        android:duration="320"
+        android:fromYDelta="0%p"
+        android:interpolator="@android:interpolator/fast_out_slow_in"
+        android:toYDelta="100%p" />
+
+    <alpha
+        android:duration="280"
+        android:fromAlpha="1.0"
+        android:toAlpha="0.96" />
+</set>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -45,6 +45,8 @@
     <string name="label_end_section">End period</string>
     <string name="toast_time_invalid">Start period cannot be greater than end period</string>
     <string name="label_course_weeks">Course weeks</string>
+    <string name="label_week_type">Week type</string>
+    <string name="week_type_every_week">Every week</string>
     <string name="action_single_week">Odd weeks</string>
     <string name="action_double_week">Even weeks</string>
     <string name="label_course_color">Course color</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="wakeup_blue">#8FB8FF</color>
+    <color name="wakeup_pink">#F4AFC8</color>
+    <color name="wakeup_green">#9FD6B5</color>
+    <color name="wakeup_yellow">#F4D68A</color>
+
+    <color name="wakeup_background">#141822</color>
+    <color name="wakeup_surface">#1B2230</color>
+
     <color name="loading_text_color">#FFFFFFFF</color>
-    <color name="widget_bg">#1C1C1E</color> # 深色背景：使用深灰色，避免纯黑拖影
-    <color name="widget_text_primary">#F2F2F7</color> # 主文字：在深色背景下改为接近纯白的亮灰色
-    <color name="widget_text_secondary">#AEA9AF</color> # 次要文字：中灰色，保持视觉层级
-    <color name="widget_text_hint">#8E8E93</color> # 提示文字：深灰色，起到弱化作用
-    <color name="widget_divider">#2C2C2E</color> # 深色分割线：比背景略亮的灰色
-    <color name="widget_course_fallback">#3A3A3C</color> # 深色模式下的课程指示条兜底色
+    <color name="widget_bg">#1C1C1E</color>
+    <color name="widget_text_primary">#F2F2F7</color>
+    <color name="widget_text_secondary">#AEA9AF</color>
+    <color name="widget_text_hint">#8E8E93</color>
+    <color name="widget_divider">#2C2C2E</color>
+    <color name="widget_course_fallback">#3A3A3C</color>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -45,6 +45,8 @@
     <string name="label_end_section">结束节次</string>
     <string name="toast_time_invalid">开始节次不能大于结束节次</string>
     <string name="label_course_weeks">上课周次</string>
+    <string name="label_week_type">单双周</string>
+    <string name="week_type_every_week">每周</string>
     <string name="action_single_week">单周</string>
     <string name="action_double_week">双周</string>
     <string name="label_course_color">课程颜色</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -45,6 +45,8 @@
     <string name="label_end_section">結束節次</string>
     <string name="toast_time_invalid">開始節次不能大於結束節次</string>
     <string name="label_course_weeks">上課週次</string>
+    <string name="label_week_type">單雙週</string>
+    <string name="week_type_every_week">每週</string>
     <string name="action_single_week">單週</string>
     <string name="action_double_week">雙週</string>
     <string name="label_course_color">課程顏色</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
+    <!-- WakeUp 风格的低饱和柔和色板 -->
+    <color name="wakeup_blue">#8FB8FF</color>
+    <color name="wakeup_pink">#F4AFC8</color>
+    <color name="wakeup_green">#9FD6B5</color>
+    <color name="wakeup_yellow">#F4D68A</color>
+
+    <color name="wakeup_background">#F6F8FC</color>
+    <color name="wakeup_surface">#FFFFFFFF</color>
+
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="loading_text_color">#FF000000</color>
-    <color name="widget_bg">#FFFFFF</color> # 小组件最底层的圆角卡片背景色
-    <color name="widget_text_primary">#2C3E50</color> # 主文字颜色：用于课程名、日期标题、假期大标题
-    <color name="widget_text_secondary">#5D6D7E</color> # 次要文字颜色：用于周次、教师名、上课地点
-    <color name="widget_text_hint">#808B96</color> # 提示文字颜色：用于无课提示、底部的统计页脚
-    <color name="widget_divider">#EAECEE</color> # 分割线颜色：用于垂直分割线和课程间的水平线
-    <color name="widget_course_fallback">#F2F4F4</color> # 课程指示条兜底色：数据异常时的默认灰色
+
+    <color name="widget_bg">#FFFFFF</color>
+    <color name="widget_text_primary">#2C3E50</color>
+    <color name="widget_text_secondary">#5D6D7E</color>
+    <color name="widget_text_hint">#808B96</color>
+    <color name="widget_divider">#EAECEE</color>
+    <color name="widget_course_fallback">#F2F4F4</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
     <string name="label_end_section">结束节次</string>
     <string name="toast_time_invalid">开始节次不能大于结束节次</string>
     <string name="label_course_weeks">上课周次</string>
+    <string name="label_week_type">单双周</string>
+    <string name="week_type_every_week">每周</string>
     <string name="action_single_week">单周</string>
     <string name="action_double_week">双周</string>
     <string name="label_course_color">课程颜色</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.shiguangschedule" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="android:windowBackground">?android:attr/colorBackground</item>
-
+        <item name="android:windowBackground">@color/wakeup_background</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 </resources>


### PR DESCRIPTION
## 性能优化

本次 PR 针对应用卡顿问题，对 4 个核心文件进行了优化：

### 1. ScheduleGrid.kt - 最大性能瓶颈修复
- ClickableGrid 从 91 个 Composable（7天×13节）减少为 1 个，使用 `pointerInput` + `detectTapGestures` 替代
- 缓存 schedulables 分组和颜色计算，减少重组开销

### 2. WeeklyScheduleViewModel.kt - 数据处理优化
- 全局缓存 `DateTimeFormatter`，避免每次调用重复创建
- 新增 `ParsedTimeSlot` 预解析结构，避免 `mergeCourses` 中反复解析时间和排序
- `fixInvalidCourseColors` 改为仅在 style 变化时触发，避免每次 collect 都启动协程

### 3. CourseBlock.kt - 重组优化
- 使用 `remember` 缓存颜色解析、字体大小计算、Shape 和自定义时间字符串
- 减少每次重组时的重复计算

### 4. WeeklyScheduleScreen.kt - 冗余计算清理
- 移除冗余的 `derivedStateOf`（`remember(key)` 已提供缓存）
- 缓存 `today` 和 `DateTimeFormatter`，避免每次重组重新获取