### PR TITLE
feat(课表): 添加当前时间段高亮显示功能

### DIFF
--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleScreen.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleScreen.kt
@@ -206,6 +206,7 @@ fun WeeklyScheduleScreen(
                     showWeekends = uiState.showWeekends,
                     todayIndex = pageTodayIndex,
                     firstDayOfWeek = uiState.firstDayOfWeek,
+                    currentSectionIndex = if (pageTodayIndex >= 0) uiState.currentSectionIndex else -1,
                     onCourseBlockClicked = { mergedBlock ->
                         if (mergedBlock.isConflict) {
                             conflictCoursesToShow = mergedBlock.courses

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleViewModel.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/WeeklyScheduleViewModel.kt
@@ -57,7 +57,8 @@ data class WeeklyScheduleUiState(
     val weekIndexInPager: Int? = null,
     val weekTitle: String = "",
     val currentWeekNumber: Int? = null,
-    val pagerMondayDate: LocalDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+    val pagerMondayDate: LocalDate = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)),
+    val currentSectionIndex: Int = -1
 )
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -157,6 +158,8 @@ class WeeklyScheduleViewModel @Inject constructor(
                     firstDayOfWeekInt = firstDayOfWeekInt
                 )
 
+                val currentSectionIndex = calculateCurrentSectionIndex(timeSlots)
+
                 // 修正颜色（仅针对本周课程做检查以减小负担）
                 val currentWeekCourses = cache[configPkg.mondayDate.toString()] ?: emptyList()
                 fixInvalidCourseColors(currentWeekCourses.flatMap { it.courses }, configPkg.style)
@@ -174,7 +177,8 @@ class WeeklyScheduleViewModel @Inject constructor(
                     weekIndexInPager = weekIndex,
                     weekTitle = generateTitle(weekIndex, startDate, totalWeeks, configPkg.provider),
                     currentWeekNumber = currentWeekNum,
-                    pagerMondayDate = configPkg.mondayDate
+                    pagerMondayDate = configPkg.mondayDate,
+                    currentSectionIndex = currentSectionIndex
                 )
             }.collect { _uiState.value = it }
         }
@@ -194,6 +198,28 @@ class WeeklyScheduleViewModel @Inject constructor(
             weekIndex != null && weekIndex in 1..totalWeeks -> p(R.string.title_current_week, arrayOf(weekIndex.toString()))
             else -> p(R.string.title_vacation, emptyArray())
         }
+    }
+
+    private fun calculateCurrentSectionIndex(timeSlots: List<TimeSlot>): Int {
+        if (timeSlots.isEmpty()) return -1
+        val now = LocalTime.now()
+        val currentMinutes = now.hour * 60 + now.minute
+        
+        timeSlots.forEachIndexed { index, slot ->
+            val startParts = slot.startTime.split(":")
+            val endParts = slot.endTime.split(":")
+            
+            if (startParts.size == 2 && endParts.size == 2) {
+                val startMinutes = startParts[0].toInt() * 60 + startParts[1].toInt()
+                val endMinutes = endParts[0].toInt() * 60 + endParts[1].toInt()
+                
+                if (currentMinutes in startMinutes until endMinutes) {
+                    return index + 1
+                }
+            }
+        }
+        
+        return -1
     }
 
     fun updatePagerDate(newDate: LocalDate) = _pagerMondayDate.update { newDate }

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
@@ -44,6 +44,7 @@ fun ScheduleGrid(
     showWeekends: Boolean,
     todayIndex: Int,
     firstDayOfWeek: Int,
+    currentSectionIndex: Int = -1,
     onCourseBlockClicked: (MergedCourseBlock) -> Unit,
     onGridCellClicked: (Int, Int) -> Unit,
     onTimeSlotClicked: () -> Unit
@@ -77,7 +78,7 @@ fun ScheduleGrid(
             DayHeader(style, displayDays, dates, currentYear, todayIndex, gridLineColor)
 
             Row(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
-                TimeColumn(style, timeSlots, onTimeSlotClicked, Modifier.height(totalGridHeight), gridLineColor)
+                TimeColumn(style, timeSlots, onTimeSlotClicked, Modifier.height(totalGridHeight), gridLineColor, currentSectionIndex)
 
                 Box(Modifier.height(totalGridHeight).weight(1f)) {
                     ClickableGrid(
@@ -172,32 +173,57 @@ private fun DayHeader(style: ScheduleGridStyleComposed, displayDays: List<String
 }
 
 @Composable
-private fun TimeColumn(style: ScheduleGridStyleComposed, timeSlots: List<TimeSlot>, onTimeSlotClicked: () -> Unit, modifier: Modifier, lineColor: Color) {
+private fun TimeColumn(style: ScheduleGridStyleComposed, timeSlots: List<TimeSlot>, onTimeSlotClicked: () -> Unit, modifier: Modifier, lineColor: Color, currentSectionIndex: Int = -1) {
     Column(modifier.width(style.timeColumnWidth)) {
-        timeSlots.forEach { slot ->
-            Column(Modifier.fillMaxWidth().height(style.sectionHeight).clickable { onTimeSlotClicked() }.drawBehind {
-                if (!style.hideGridLines) {
-                    // 右侧线与底部线
-                    drawLine(lineColor, Offset(size.width, 0f), Offset(size.width, size.height), 1f)
-                    drawLine(lineColor, Offset(0f, size.height), Offset(size.width, size.height), 1f)
-                }
-            }, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+        timeSlots.forEachIndexed { index, slot ->
+            val isCurrentSection = index + 1 == currentSectionIndex
+            val backgroundColor = if (isCurrentSection) {
+                MaterialTheme.colorScheme.secondaryContainer
+            } else {
+                Color.Transparent
+            }
+            val textColor = if (isCurrentSection) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            }
+            val timeColor = if (isCurrentSection) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(style.sectionHeight)
+                    .clickable { onTimeSlotClicked() }
+                    .background(backgroundColor)
+                    .drawBehind {
+                        if (!style.hideGridLines) {
+                            drawLine(lineColor, Offset(size.width, 0f), Offset(size.width, size.height), 1f)
+                            drawLine(lineColor, Offset(0f, size.height), Offset(size.width, size.height), 1f)
+                        }
+                    },
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(
                     text = slot.number.toString(),
                     fontSize = 16.sp,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
+                    color = textColor
                 )
                 if (!style.hideSectionTime) {
                     Text(
                         text = slot.startTime,
                         fontSize = 10.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = timeColor
                     )
                     Text(
                         text = slot.endTime,
                         fontSize = 10.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = timeColor
                     )
                 }
             }

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/ui/schedule/components/ScheduleGrid.kt
@@ -178,17 +178,17 @@ private fun TimeColumn(style: ScheduleGridStyleComposed, timeSlots: List<TimeSlo
         timeSlots.forEachIndexed { index, slot ->
             val isCurrentSection = index + 1 == currentSectionIndex
             val backgroundColor = if (isCurrentSection) {
-                MaterialTheme.colorScheme.secondaryContainer
+                MaterialTheme.colorScheme.primaryContainer.copy(0.4f)
             } else {
                 Color.Transparent
             }
             val textColor = if (isCurrentSection) {
-                MaterialTheme.colorScheme.onPrimaryContainer
+                MaterialTheme.colorScheme.onSurface
             } else {
                 MaterialTheme.colorScheme.onSurface
             }
             val timeColor = if (isCurrentSection) {
-                MaterialTheme.colorScheme.onPrimaryContainer
+                MaterialTheme.colorScheme.onSurfaceVariant
             } else {
                 MaterialTheme.colorScheme.onSurfaceVariant
             }


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [ ] 文件已经上传,到对应的学校资源文件
* [x] **确认目标分支是 `dev`。** (请勿直接合并到 `main` 或其他发布分支。)


## PR 描述 (Description)

本次 PR 解决了什么问题？/ 引入了哪些新功能？(可以不填写)  

在课表视图中高亮显示当前时间段，提升用户体验。通过计算当前时间所在的时间段索引，并在UI中使用不同的背景色和文字颜色突出显示。

- 自动检测当前节次 ：应用会根据系统当前时间自动判断当前正在上课的节次
- 视觉高亮 ：当前节次在左侧时间列中会以 secondaryContainer 背景色高亮显示，文字颜色使用 onPrimaryContainer
- 上下文感知 ：只在显示"今天"的周视图中高亮当前节次，避免在查看其他周时产生混淆
- 动态更新 ：由于使用了 StateFlow，当时间变化导致当前节次改变时，UI 会自动更新
技术实现：

1. 在 WeeklyScheduleViewModel 中添加了 calculateCurrentSectionIndex() 函数，根据当前时间与时间槽的匹配关系计算当前节次索引
2. 在 WeeklyScheduleUiState 中添加了 currentSectionIndex 字段存储当前节次
3. 修改 TimeColumn 组件，根据 currentSectionIndex 参数动态调整节次的背景色和文字颜色
4. 在 WeeklyScheduleScreen 中传递 currentSectionIndex 参数，仅在当前显示周包含"今天"时启用高亮功能