### PR TITLE
feat: add widget refresh diagnostics store

### DIFF
--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetRefreshDiagnosticsStore.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetRefreshDiagnosticsStore.kt
@@ -1,0 +1,78 @@
+package com.xingheyuzhuan.shiguangschedule.widget
+
+import android.content.Context
+import android.util.Log
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/** 单次桌面小组件刷新诊断记录。 */
+data class WidgetRefreshLogEntry(
+    val timestampMillis: Long,
+    val reason: WidgetRefreshReason,
+    val success: Boolean,
+    val durationMillis: Long,
+    val message: String
+)
+
+/**
+ * 桌面小组件刷新诊断日志。
+ *
+ * 使用 SharedPreferences 保存最近若干条记录，避免引入 Room schema 迁移；
+ * 进程被杀后仍能保留最近刷新状态，方便无人值守排障。
+ */
+object WidgetRefreshDiagnosticsStore {
+    private const val TAG = "WidgetRefreshDiag"
+    private const val PREF_NAME = "widget_refresh_diagnostics"
+    private const val KEY_RECENT_RECORDS = "recent_records"
+    private const val MAX_RECORDS = 30
+    private const val DELIMITER = "\t"
+
+    fun append(context: Context, entry: WidgetRefreshLogEntry) {
+        synchronized(this) {
+            val records = readRecent(context).toMutableList()
+            records.add(0, entry)
+            val encoded = records.take(MAX_RECORDS).joinToString("\n") { encode(it) }
+            context.applicationContext
+                .getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_RECENT_RECORDS, encoded)
+                .apply()
+        }
+    }
+
+    fun readRecent(context: Context): List<WidgetRefreshLogEntry> {
+        val raw = context.applicationContext
+            .getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_RECENT_RECORDS, null)
+            .orEmpty()
+        if (raw.isBlank()) return emptyList()
+        return raw.lineSequence().mapNotNull { decode(it) }.toList()
+    }
+
+    fun latest(context: Context): WidgetRefreshLogEntry? = readRecent(context).firstOrNull()
+
+    internal fun encode(entry: WidgetRefreshLogEntry): String {
+        val encodedMessage = Base64.getEncoder().encodeToString(entry.message.toByteArray(StandardCharsets.UTF_8))
+        return listOf(
+            entry.timestampMillis.toString(),
+            entry.reason.name,
+            entry.success.toString(),
+            entry.durationMillis.toString(),
+            encodedMessage
+        ).joinToString(DELIMITER)
+    }
+
+    internal fun decode(line: String): WidgetRefreshLogEntry? = runCatching {
+        val parts = line.split(DELIMITER, limit = 5)
+        if (parts.size != 5) return@runCatching null
+        WidgetRefreshLogEntry(
+            timestampMillis = parts[0].toLong(),
+            reason = WidgetRefreshReason.fromName(parts[1]),
+            success = parts[2].toBooleanStrict(),
+            durationMillis = parts[3].toLong(),
+            message = String(Base64.getDecoder().decode(parts[4]), StandardCharsets.UTF_8)
+        )
+    }.onFailure { error ->
+        Log.w(TAG, "解析小组件刷新诊断记录失败: $line", error)
+    }.getOrNull()
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetRefreshReason.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetRefreshReason.kt
@@ -1,0 +1,25 @@
+package com.xingheyuzhuan.shiguangschedule.widget
+
+/**
+ * 桌面小组件刷新原因。
+ *
+ * v1.3.0 将所有主动刷新统一标记原因，便于诊断“设置已变但小组件未变”的问题。
+ */
+enum class WidgetRefreshReason(val displayName: String) {
+    SYSTEM_UPDATE("系统请求刷新"),
+    PERIODIC("周期兜底刷新"),
+    FULL_DATA_SYNC("完整数据同步"),
+    COURSE_DATA_CHANGED("课程数据变化"),
+    COURSE_TABLE_SWITCHED("当前课表切换"),
+    COURSE_TABLE_CONFIG_CHANGED("课表配置变化"),
+    STYLE_CHANGED("样式配置变化"),
+    WIDGET_STYLE_PREVIEW("桌面小组件样式预览"),
+    WIDGET_STYLE_CHANGED("桌面小组件样式保存"),
+    CALENDAR_ALARM("课程提醒触发"),
+    MANUAL("用户手动刷新"),
+    UNKNOWN("未知原因");
+
+    companion object {
+        fun fromName(name: String?): WidgetRefreshReason = entries.firstOrNull { it.name == name } ?: UNKNOWN
+    }
+}

--- a/app/src/test/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetRefreshDiagnosticsStoreTest.kt
+++ b/app/src/test/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetRefreshDiagnosticsStoreTest.kt
@@ -1,0 +1,36 @@
+package com.xingheyuzhuan.shiguangschedule.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class WidgetRefreshDiagnosticsStoreTest {
+
+    @Test
+    fun encodeAndDecode_preservesRefreshLogEntry() {
+        val entry = WidgetRefreshLogEntry(
+            timestampMillis = 1783340000000L,
+            reason = WidgetRefreshReason.COURSE_TABLE_CONFIG_CHANGED,
+            success = false,
+            durationMillis = 234L,
+            message = "周末显示设置同步失败：launcher cache"
+        )
+
+        val decoded = WidgetRefreshDiagnosticsStore.decode(
+            WidgetRefreshDiagnosticsStore.encode(entry)
+        )
+
+        assertNotNull(decoded)
+        assertEquals(entry, decoded)
+    }
+
+    @Test
+    fun decode_whenReasonUnknown_fallsBackToUnknown() {
+        val line = "1783340000000\tNOT_EXIST\ttrue\t12\t5Yi35paw5a6M5oiQ"
+
+        val decoded = WidgetRefreshDiagnosticsStore.decode(line)
+
+        assertNotNull(decoded)
+        assertEquals(WidgetRefreshReason.UNKNOWN, decoded?.reason)
+    }
+}


### PR DESCRIPTION
## 本次 PR 解决的问题

为桌面小组件刷新链路增加基础诊断能力，便于后续定位“小组件未及时刷新”或“刷新来源不明确”等问题。

## 主要改动

- 新增 `WidgetRefreshReason`，统一描述小组件刷新来源。
- 新增 `WidgetRefreshDiagnosticsStore`，使用 SharedPreferences 保存最近的小组件刷新诊断记录。
- 新增 `WidgetRefreshLogEntry`，记录刷新时间、刷新原因、成功状态、耗时和消息。
- 新增 `WidgetRefreshDiagnosticsStoreTest`，覆盖诊断记录编码/解码逻辑。

## 说明

该 PR 只新增诊断基础设施，不改变现有小组件刷新逻辑，方便后续 PR 逐步接入统一刷新协调器。

## 测试情况

- [ ] 代码已经经过实机测试
- [x] 确认目标分支是 `dev`
- [ ] 本地运行 `testDebugUnitTest`

本地测试未能完成，原因是当前环境下载 Gradle Wrapper 发行包时访问 `services.gradle.org` 超时：

```text
Downloading https://services.gradle.org/distributions/gradle-9.6.1-bin.zip failed