### PR TITLE
feat: add week timeline schedule widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,23 @@
                 android:resource="@xml/shiguangschedule_list_vertical_widget" />
         </receiver>
 
+        <receiver
+            android:name=".widget.week_timeline.WeekTimelineNativeProvider"
+            android:exported="false"
+            android:label="@string/widget_name_week_timeline">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/shiguangschedule_week_timeline_widget" />
+        </receiver>
+
+        <service
+            android:name=".widget.week_timeline.WeekTimelineRemoteViewsService"
+            android:exported="false"
+            android:permission="android.permission.BIND_REMOTEVIEWS" />
+
 
 
         <provider

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/di/DataStoreModule.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/data/di/DataStoreModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 // 定义 AppSettings Preferences DataStore 委托
-private val Context.appSettingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
+val Context.appSettingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "app_settings")
 // 定义 SchoolHistory Preferences DataStore 委托
 private val Context.schoolHistoryDataStore: DataStore<Preferences> by preferencesDataStore(name = "school_history")
 

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetSnapshotLoader.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetSnapshotLoader.kt
@@ -1,0 +1,220 @@
+package com.xingheyuzhuan.shiguangschedule.widget
+
+import android.content.Context
+import com.xingheyuzhuan.shiguangschedule.data.db.main.CourseTableConfig
+import com.xingheyuzhuan.shiguangschedule.data.db.main.CourseWithWeeks
+import com.xingheyuzhuan.shiguangschedule.data.db.main.MainAppDatabase
+import com.xingheyuzhuan.shiguangschedule.data.db.main.TimeSlot
+import com.xingheyuzhuan.shiguangschedule.data.di.appSettingsDataStore
+import com.xingheyuzhuan.shiguangschedule.data.model.AppSettingsModel
+import com.xingheyuzhuan.shiguangschedule.data.model.ScheduleGridStyle
+import com.xingheyuzhuan.shiguangschedule.data.model.toProto
+import com.xingheyuzhuan.shiguangschedule.data.repository.scheduleGridStyleDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+object WidgetSnapshotLoader {
+    private const val WIDGET_SYNC_DAYS = 7L
+
+    suspend fun load(
+        context: Context,
+        widgetCourseFontScaleOverride: Float? = null
+    ): WidgetSnapshot {
+        val mainDb = MainAppDatabase.getDatabase(context)
+        val today = LocalDate.now()
+
+        val currentStyle = withTimeoutOrNull(2000L) {
+            context.scheduleGridStyleDataStore.data.first()
+        }
+
+        val finalStyleToSync = (currentStyle ?: ScheduleGridStyle.DEFAULT.toProto())
+            .let { baseStyle ->
+                if (baseStyle.course_color_maps.isEmpty()) {
+                    baseStyle.copy(course_color_maps = ScheduleGridStyle.DEFAULT.toProto().course_color_maps)
+                } else {
+                    baseStyle
+                }
+            }
+            .let { baseStyle ->
+                val overrideScale = widgetCourseFontScaleOverride?.coerceIn(0.5f, 2.0f)
+                if (overrideScale != null) {
+                    baseStyle.copy(widget_course_font_scale = overrideScale)
+                } else {
+                    baseStyle
+                }
+            }
+
+        val fallbackCourseTable = withTimeoutOrNull(2000L) {
+            mainDb.courseTableDao().getFirstTableOnce()
+        }
+        val fallbackCourseTableId = fallbackCourseTable?.id.orEmpty()
+
+        val currentAppSettings = withTimeoutOrNull(2000L) {
+            context.appSettingsDataStore.data.first().let { prefs ->
+                AppSettingsModel.fromPreferences(prefs, fallbackTableId = fallbackCourseTableId)
+            }
+        }
+
+        val resolvedCourseTableId = currentAppSettings?.currentCourseTableId
+            ?.takeIf { it.isNotBlank() }
+            ?: fallbackCourseTableId
+
+        val currentCourseTable = withTimeoutOrNull(2000L) {
+            mainDb.courseTableDao().getCourseTableById(resolvedCourseTableId)
+                ?: fallbackCourseTable
+        } ?: fallbackCourseTable
+
+        val currentCourseTableName = currentCourseTable?.name.orEmpty()
+        val currentCourseConfig = if (resolvedCourseTableId.isBlank()) {
+            null
+        } else {
+            withTimeoutOrNull(2000L) {
+                mainDb.courseTableConfigDao().getConfigOnce(resolvedCourseTableId)
+            }
+        }
+        val firstDayOfWeek = currentCourseConfig?.firstDayOfWeek?.takeIf { it in 1..7 } ?: 1
+        val showWeekends = currentCourseConfig?.showWeekends ?: false
+
+        val timeSlots = if (resolvedCourseTableId.isBlank()) {
+            emptyList()
+        } else {
+            withTimeoutOrNull(2000L) {
+                mainDb.timeSlotDao()
+                    .getTimeSlotsByCourseTableId(resolvedCourseTableId)
+                    .first()
+                    .filter { it.number > 0 && it.startTime.isNotBlank() }
+                    .sortedBy { it.number }
+            } ?: emptyList()
+        }
+        val timeSlotProtoList = timeSlots.map { slot ->
+            WidgetTimeSlotProto(
+                number = slot.number,
+                start_time = slot.startTime,
+                end_time = slot.endTime
+            )
+        }
+
+        val coursesWithWeeks = if (resolvedCourseTableId.isBlank()) {
+            emptyList()
+        } else {
+            withTimeoutOrNull(3000L) {
+                mainDb.courseDao().getCoursesWithWeeksByTableId(resolvedCourseTableId).first()
+            } ?: emptyList()
+        }
+
+        val courseProtoList = buildCourseSnapshotCourses(
+            today = today,
+            appSettings = currentAppSettings,
+            config = currentCourseConfig,
+            coursesWithWeeks = coursesWithWeeks,
+            timeSlots = timeSlots
+        )
+
+        return WidgetSnapshot(
+            current_week = calculateCurrentWeek(
+                today = today,
+                config = currentCourseConfig,
+                firstDayOfWeek = firstDayOfWeek
+            ) ?: 0,
+            style = finalStyleToSync,
+            courses = courseProtoList,
+            time_slots = timeSlotProtoList,
+            course_table_name = currentCourseTableName,
+            show_weekends = showWeekends,
+            first_day_of_week = firstDayOfWeek
+        )
+    }
+
+    private fun buildCourseSnapshotCourses(
+        today: LocalDate,
+        appSettings: AppSettingsModel?,
+        config: CourseTableConfig?,
+        coursesWithWeeks: List<CourseWithWeeks>,
+        timeSlots: List<TimeSlot>
+    ): List<WidgetCourseProto> {
+        val semesterStartDateText = config?.semesterStartDate ?: return emptyList()
+        val semesterTotalWeeks = config.semesterTotalWeeks
+        if (semesterTotalWeeks <= 0) return emptyList()
+
+        val firstDayOfWeek = config.firstDayOfWeek.takeIf { it in 1..7 } ?: 1
+        val semesterStartDate = runCatching { LocalDate.parse(semesterStartDateText) }.getOrNull()
+            ?: return emptyList()
+        val alignedSemesterStartDate = startOfConfiguredWeek(semesterStartDate, firstDayOfWeek)
+        val displayWeekStartDate = startOfConfiguredWeek(today, firstDayOfWeek)
+        val displayWeekEndDate = displayWeekStartDate.plusDays(6)
+        val futureSyncEndDate = today.plusDays(WIDGET_SYNC_DAYS - 1)
+        val startSyncDate = if (today.isBefore(alignedSemesterStartDate)) {
+            alignedSemesterStartDate
+        } else {
+            minOf(displayWeekStartDate, today)
+        }
+        val endSyncDate = if (today.isBefore(alignedSemesterStartDate)) {
+            alignedSemesterStartDate.plusDays(WIDGET_SYNC_DAYS - 1)
+        } else {
+            maxOf(displayWeekEndDate, futureSyncEndDate)
+        }
+
+        val timeSlotMap = timeSlots.associateBy { it.number }
+        val skippedDates = appSettings?.skippedDates.orEmpty()
+        val result = mutableListOf<WidgetCourseProto>()
+        val syncDays = ChronoUnit.DAYS.between(startSyncDate, endSyncDate).toInt() + 1
+
+        for (offset in 0 until syncDays) {
+            val date = startSyncDate.plusDays(offset.toLong())
+            val alignedDate = startOfConfiguredWeek(date, firstDayOfWeek)
+            val weekNumber = ChronoUnit.WEEKS.between(alignedSemesterStartDate, alignedDate).toInt() + 1
+            if (weekNumber !in 1..semesterTotalWeeks) continue
+
+            val dayOfWeek = date.dayOfWeek.value
+            val dateText = date.toString()
+
+            coursesWithWeeks.forEach { courseWithWeeks ->
+                if (courseWithWeeks.course.day != dayOfWeek) return@forEach
+                if (courseWithWeeks.weeks.none { it.weekNumber == weekNumber }) return@forEach
+
+                val course = courseWithWeeks.course
+                val (startTime, endTime) = if (course.isCustomTime) {
+                    (course.customStartTime ?: "") to (course.customEndTime ?: "")
+                } else {
+                    (timeSlotMap[course.startSection]?.startTime ?: "") to
+                        (timeSlotMap[course.endSection]?.endTime ?: "")
+                }
+
+                result += WidgetCourseProto(
+                    id = "${course.id}-$dateText",
+                    name = course.name,
+                    teacher = course.teacher,
+                    position = course.position,
+                    start_time = startTime,
+                    end_time = endTime,
+                    color_int = course.colorInt,
+                    is_skipped = skippedDates.contains(dateText),
+                    date = dateText
+                )
+            }
+        }
+
+        return result.sortedWith(compareBy({ it.date }, { it.start_time }, { it.name }))
+    }
+
+    private fun calculateCurrentWeek(
+        today: LocalDate,
+        config: CourseTableConfig?,
+        firstDayOfWeek: Int
+    ): Int? {
+        val semesterStartDateText = config?.semesterStartDate ?: return null
+        val semesterTotalWeeks = config.semesterTotalWeeks
+        if (semesterTotalWeeks <= 0) return null
+
+        val semesterStartDate = runCatching { LocalDate.parse(semesterStartDateText) }.getOrNull()
+            ?: return null
+        val alignedSemesterStartDate = startOfConfiguredWeek(semesterStartDate, firstDayOfWeek)
+        val alignedToday = startOfConfiguredWeek(today, firstDayOfWeek)
+        if (alignedToday.isBefore(alignedSemesterStartDate)) return null
+
+        val weekNumber = ChronoUnit.WEEKS.between(alignedSemesterStartDate, alignedToday).toInt() + 1
+        return weekNumber.takeIf { it in 1..semesterTotalWeeks }
+    }
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetTextSizeHelper.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetTextSizeHelper.kt
@@ -1,0 +1,17 @@
+package com.xingheyuzhuan.shiguangschedule.widget
+
+import android.util.TypedValue
+import android.widget.RemoteViews
+
+private const val DEFAULT_WIDGET_COURSE_FONT_SCALE = 1f
+
+fun WidgetSnapshot.widgetCourseFontScale(): Float {
+    return style?.widget_course_font_scale
+        ?.takeIf { it > 0f }
+        ?.coerceIn(0.5f, 2.0f)
+        ?: DEFAULT_WIDGET_COURSE_FONT_SCALE
+}
+
+fun RemoteViews.setScaledTextSize(viewId: Int, baseSp: Float, scale: Float) {
+    setTextViewTextSize(viewId, TypedValue.COMPLEX_UNIT_SP, baseSp * scale)
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetUpdateHelper.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetUpdateHelper.kt
@@ -1,14 +1,10 @@
-package com.xingheyuzhuan.shiguangschedule.widget
+﻿package com.xingheyuzhuan.shiguangschedule.widget
 
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
-import com.xingheyuzhuan.shiguangschedule.data.db.widget.WidgetDatabase
-import com.xingheyuzhuan.shiguangschedule.data.model.ScheduleGridStyle
-import com.xingheyuzhuan.shiguangschedule.data.model.toProto
-import com.xingheyuzhuan.shiguangschedule.data.repository.WidgetRepository
-import com.xingheyuzhuan.shiguangschedule.data.repository.scheduleGridStyleDataStore
 import com.xingheyuzhuan.shiguangschedule.widget.compact.CompactNativeProvider
 import com.xingheyuzhuan.shiguangschedule.widget.compact.CompactNativeRenderer
 import com.xingheyuzhuan.shiguangschedule.widget.double_days.DoubleDaysNativeProvider
@@ -17,75 +13,21 @@ import com.xingheyuzhuan.shiguangschedule.widget.list_vertical.ListVerticalNativ
 import com.xingheyuzhuan.shiguangschedule.widget.list_vertical.ListVerticalNativeRenderer
 import com.xingheyuzhuan.shiguangschedule.widget.tiny.TinyNativeProvider
 import com.xingheyuzhuan.shiguangschedule.widget.tiny.TinyNativeRenderer
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeoutOrNull
-import java.time.LocalDate
+import com.xingheyuzhuan.shiguangschedule.widget.week_timeline.WeekTimelineLayoutSlotStore
+import com.xingheyuzhuan.shiguangschedule.widget.week_timeline.WeekTimelineNativeProvider
+import com.xingheyuzhuan.shiguangschedule.widget.week_timeline.WeekTimelineNativeRenderer
+import kotlinx.coroutines.delay
 
 /**
  * 小组件统一分发中心
  * 负责从 Repository 提取数据并分发给所有 5 种规格的原生 Renderer
  */
-suspend fun updateAllWidgets(context: Context) {
+suspend fun updateAllWidgets(
+    context: Context,
+    widgetCourseFontScaleOverride: Float? = null
+) {
     try {
-        // 1. 初始化数据库和仓库
-        val widgetDb = WidgetDatabase.getDatabase(context)
-        val repository = WidgetRepository(
-            widgetCourseDao = widgetDb.widgetCourseDao(),
-            widgetAppSettingsDao = widgetDb.widgetAppSettingsDao(),
-            context = context
-        )
-
-        // 2. 准备基础数据
-        val today = LocalDate.now()
-        val tomorrow = today.plusDays(1)
-
-        // 获取今日和明日的所有课程快照 (超时时间 3秒)
-        val dbCourses = withTimeoutOrNull(3000L) {
-            repository.getWidgetCoursesByDateRange(today.toString(), tomorrow.toString()).first()
-        } ?: emptyList() // 超时则返回空列表
-
-        // 获取当前周 (超时时间 2秒)
-        val currentWeek = withTimeoutOrNull(2000L) {
-            repository.getCurrentWeekFlow().first()
-        } ?: 0
-
-        // 获取样式 (超时时间 2秒)
-        val currentStyle = withTimeoutOrNull(2000L) {
-            context.scheduleGridStyleDataStore.data.first()
-        }
-
-        // 样式保底逻辑
-        val finalStyleToSync = if (currentStyle == null || currentStyle.course_color_maps.isEmpty()) {
-            ScheduleGridStyle.DEFAULT.toProto()
-        } else {
-            currentStyle
-        }
-
-        // 3. 构造数据快照 (Protobuf)
-
-        // 先将数据库实体转为 Wire 的 WidgetCourseProto 对象
-        val courseProtoList = dbCourses.map { course ->
-            WidgetCourseProto(
-                id = course.id,
-                name = course.name,
-                teacher = course.teacher,
-                position = course.position,
-                start_time = course.startTime,
-                end_time = course.endTime,
-                color_int = course.colorInt,
-                is_skipped = course.isSkipped,
-                date = course.date
-            )
-        }
-
-        // 直接通过构造函数创建快照对象
-        val snapshot = WidgetSnapshot(
-            current_week = currentWeek,
-            style = finalStyleToSync,
-            courses = courseProtoList
-        )
-
-        // 4. 定义所有原生尺寸的映射列表
+        val snapshot = WidgetSnapshotLoader.load(context, widgetCourseFontScaleOverride)
         val appWidgetManager = AppWidgetManager.getInstance(context)
         val nativeConfigs = listOf(
             TinyNativeProvider::class.java to TinyNativeRenderer::render,
@@ -94,27 +36,89 @@ suspend fun updateAllWidgets(context: Context) {
             ListVerticalNativeProvider::class.java to ListVerticalNativeRenderer::render
         )
 
-        // 5. 统一分发更新
         nativeConfigs.forEachIndexed { index, (providerClass, renderFunc) ->
             val componentName = ComponentName(context, providerClass)
             val ids = appWidgetManager.getAppWidgetIds(componentName)
+            if (ids.isEmpty()) return@forEachIndexed
 
-            if (ids.isNotEmpty()) {
-                if (index > 0) {
-                    kotlinx.coroutines.delay(300L)
-                }
+            if (index > 0) {
+                delay(300L)
+            }
 
-                try {
-                    val remoteViews = renderFunc(context, snapshot)
-                    appWidgetManager.updateAppWidget(componentName, remoteViews)
-                    Log.d("WidgetUpdateHelper", "成功刷新规格 ${providerClass.simpleName}")
-                } catch (e: Exception) {
-                    Log.e("WidgetUpdateHelper", "规格 ${providerClass.simpleName} 渲染失败", e)
-                }
+            try {
+                val remoteViews = renderFunc(context, snapshot)
+                appWidgetManager.updateAppWidget(componentName, remoteViews)
+                Log.d("WidgetUpdateHelper", "成功刷新规格 ${providerClass.simpleName}")
+            } catch (error: Exception) {
+                Log.e("WidgetUpdateHelper", "规格 ${providerClass.simpleName} 渲染失败", error)
             }
         }
 
-    } catch (e: Exception) {
-        Log.e("WidgetUpdateHelper", "更新流程异常: ${e.stackTraceToString()}")
+        val weekTimelineComponent = ComponentName(context, WeekTimelineNativeProvider::class.java)
+        val weekTimelineIds = appWidgetManager.getAppWidgetIds(weekTimelineComponent)
+        if (weekTimelineIds.isNotEmpty()) {
+            delay(300L)
+            refreshWeekTimelineWidgets(
+                context = context,
+                appWidgetManager = appWidgetManager,
+                appWidgetIds = weekTimelineIds,
+                snapshot = snapshot,
+                toggleLayoutSlot = true
+            )
+            delay(220L)
+            val confirmedSnapshot = WidgetSnapshotLoader.load(context, widgetCourseFontScaleOverride)
+            refreshWeekTimelineWidgets(
+                context = context,
+                appWidgetManager = appWidgetManager,
+                appWidgetIds = weekTimelineIds,
+                snapshot = confirmedSnapshot,
+                toggleLayoutSlot = false
+            )
+            Log.d(
+                "WidgetUpdateHelper",
+                "成功刷新规格 ${WeekTimelineNativeProvider::class.java.simpleName}，showWeekends=${confirmedSnapshot.show_weekends}"
+            )
+        }
+    } catch (error: Exception) {
+        Log.e("WidgetUpdateHelper", "更新流程异常: ${error.stackTraceToString()}")
+    }
+}
+
+private fun refreshWeekTimelineWidgets(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetIds: IntArray,
+    snapshot: WidgetSnapshot,
+    toggleLayoutSlot: Boolean
+) {
+    val renderToken = SystemClock.elapsedRealtimeNanos()
+    WeekTimelineNativeRenderer.collectionViewIds.forEach { collectionViewId ->
+        appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, collectionViewId)
+    }
+    appWidgetIds.forEach { appWidgetId ->
+        try {
+            val activeLayoutSlot = if (toggleLayoutSlot) {
+                WeekTimelineLayoutSlotStore.advance(context, appWidgetId)
+            } else {
+                WeekTimelineLayoutSlotStore.current(context, appWidgetId)
+            }
+            val remoteViews = WeekTimelineNativeRenderer.render(
+                context = context,
+                snapshot = snapshot,
+                appWidgetId = appWidgetId,
+                renderToken = renderToken,
+                activeLayoutSlot = activeLayoutSlot
+            )
+            appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
+            Log.d(
+                "WidgetUpdateHelper",
+                "周视图小组件刷新 appWidgetId=$appWidgetId, showWeekends=${snapshot.show_weekends}, hash=${snapshot.hashCode()}, renderToken=$renderToken"
+            )
+        } catch (error: Exception) {
+            Log.e("WidgetUpdateHelper", "周视图小组件渲染失败，appWidgetId=$appWidgetId", error)
+        }
+    }
+    WeekTimelineNativeRenderer.collectionViewIds.forEach { collectionViewId ->
+        appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, collectionViewId)
     }
 }

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetWeekHelper.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/WidgetWeekHelper.kt
@@ -1,0 +1,16 @@
+package com.xingheyuzhuan.shiguangschedule.widget
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+fun WidgetSnapshot.firstDayOfWeekValue(): Int {
+    return first_day_of_week.takeIf { it in DayOfWeek.MONDAY.value..DayOfWeek.SUNDAY.value }
+        ?: DayOfWeek.MONDAY.value
+}
+
+fun startOfConfiguredWeek(date: LocalDate, firstDayOfWeek: Int): LocalDate {
+    val normalizedDay = firstDayOfWeek.takeIf { it in DayOfWeek.MONDAY.value..DayOfWeek.SUNDAY.value }
+        ?: DayOfWeek.MONDAY.value
+    return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.of(normalizedDay)))
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineBodyRenderer.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineBodyRenderer.kt
@@ -1,0 +1,485 @@
+﻿package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.text.TextPaint
+import androidx.core.graphics.ColorUtils
+import com.xingheyuzhuan.shiguangschedule.widget.WidgetCourseProto
+import com.xingheyuzhuan.shiguangschedule.widget.WidgetSnapshot
+import com.xingheyuzhuan.shiguangschedule.widget.firstDayOfWeekValue
+import com.xingheyuzhuan.shiguangschedule.widget.startOfConfiguredWeek
+import com.xingheyuzhuan.shiguangschedule.widget.widgetCourseFontScale
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+import kotlin.math.max
+import kotlin.math.min
+
+object WeekTimelineBodyRenderer {
+    private const val BODY_BITMAP_WIDTH = 560
+    private const val LEFT_INFO_WEIGHT = 64f
+    private const val DAYS_TOTAL_WEIGHT = 497f
+    private const val TOP_PADDING = 4f
+    private const val BOTTOM_PADDING = 8f
+    private const val LEFT_INFO_TEXT_CENTER_OFFSET = 2f
+    private const val MIN_SLOT_HEIGHT = 76f
+    private const val DEFAULT_SLOT_HEIGHT = 82f
+    private const val DEFAULT_EMPTY_HINT_SEGMENT_COUNT = 1
+
+    private val fallbackSectionSlots = listOf(
+        SectionSlot(1, "08:00", "08:45"),
+        SectionSlot(2, "08:50", "09:35"),
+        SectionSlot(3, "09:55", "10:40"),
+        SectionSlot(4, "10:45", "11:30"),
+        SectionSlot(5, "14:00", "14:45"),
+        SectionSlot(6, "14:50", "15:35"),
+        SectionSlot(7, "15:55", "16:40"),
+        SectionSlot(8, "16:55", "17:30"),
+        SectionSlot(9, "19:00", "19:45"),
+        SectionSlot(10, "19:50", "20:35")
+    )
+
+    fun renderBodyBitmap(snapshot: WidgetSnapshot): Bitmap {
+        val layout = buildLayout(snapshot)
+        val fullSegment = WeekTimelineSegment(
+            startSlotIndex = 0,
+            endSlotIndex = layout.sectionSlots.lastIndex
+        )
+        return renderSegmentBitmap(layout, fullSegment)
+    }
+
+    internal fun renderSegmentBitmap(snapshot: WidgetSnapshot, segment: WeekTimelineSegment): Bitmap {
+        return renderSegmentBitmap(buildLayout(snapshot), segment)
+    }
+
+    internal fun buildSegments(snapshot: WidgetSnapshot): List<WeekTimelineSegment> {
+        val slotCount = sectionSlotsFromSnapshot(snapshot).size
+        return buildWeekTimelineSegments(slotCount)
+    }
+
+    private fun renderSegmentBitmap(
+        layout: WeekTimelineLayout,
+        requestedSegment: WeekTimelineSegment
+    ): Bitmap {
+        val segment = requestedSegment.coerceWithin(layout.sectionSlots.lastIndex)
+        val segmentSlots = layout.sectionSlots.subList(segment.startSlotIndex, segment.endSlotIndex + 1)
+        val bitmapHeight = (TOP_PADDING + segmentSlots.size * layout.slotHeight + BOTTOM_PADDING)
+            .toInt()
+            .coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(BODY_BITMAP_WIDTH, bitmapHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.TRANSPARENT)
+
+        val leftColumnWidth = BODY_BITMAP_WIDTH * LEFT_INFO_WEIGHT / (LEFT_INFO_WEIGHT + DAYS_TOTAL_WEIGHT)
+        val gridStart = leftColumnWidth
+        val gridWidth = BODY_BITMAP_WIDTH - gridStart
+        val dayWidth = gridWidth / layout.weekDates.size.coerceAtLeast(1)
+        val timelineTop = TOP_PADDING
+        val timelineBottom = bitmapHeight - BOTTOM_PADDING
+        val linePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = layout.dividerColor
+            strokeWidth = 1.15f
+        }
+
+        canvas.drawLine(gridStart - 3f, timelineTop, gridStart - 3f, timelineBottom, linePaint)
+        (1 until layout.weekDates.size).forEach { index ->
+            val x = gridStart + dayWidth * index
+            canvas.drawLine(x, timelineTop, x, timelineBottom, linePaint)
+        }
+
+        segmentSlots.forEachIndexed { index, slot ->
+            val top = timelineTop + index * layout.slotHeight
+            val centerY = top + layout.slotHeight * 0.5f
+            val centerX = leftColumnWidth / 2f - LEFT_INFO_TEXT_CENTER_OFFSET
+            val sectionSize = if (layout.useCompactSlotText) 16f else 18.5f
+            val timeSize = if (layout.useCompactSlotText) 8.5f else 9.6f
+            val lineGap = if (layout.useCompactSlotText) 12f else 14.5f
+
+            drawCenteredText(canvas, slot.section.toString(), centerX, centerY - lineGap, sectionSize, layout.primaryTextColor, bold = true)
+            drawCenteredText(canvas, slot.start, centerX, centerY + 1f, timeSize, layout.hintTextColor)
+            if (slot.end.isNotBlank()) {
+                drawCenteredText(canvas, slot.end, centerX, centerY + lineGap, timeSize, layout.hintTextColor)
+            }
+
+            if (index > 0 || segment.startSlotIndex > 0) {
+                canvas.drawLine(0f, top, BODY_BITMAP_WIDTH.toFloat(), top, linePaint)
+            }
+        }
+
+        if (layout.events.isEmpty()) {
+            if (segment.startSlotIndex < DEFAULT_EMPTY_HINT_SEGMENT_COUNT * 4) {
+                drawEmptyWeekHint(
+                    canvas = canvas,
+                    gridStart = gridStart,
+                    gridWidth = gridWidth,
+                    timelineTop = timelineTop,
+                    timelineBottom = timelineBottom,
+                    primaryText = layout.primaryTextColor,
+                    hintText = layout.hintTextColor
+                )
+            }
+        } else {
+            drawWeekCoursesForSegment(
+                canvas = canvas,
+                layout = layout,
+                segment = segment,
+                gridStart = gridStart,
+                dayWidth = dayWidth,
+                timelineTop = timelineTop,
+                timelineBottom = timelineBottom
+            )
+        }
+
+        return bitmap
+    }
+
+    private fun buildLayout(snapshot: WidgetSnapshot): WeekTimelineLayout {
+        val weekDates = buildWeekDates(snapshot)
+        val sectionSlots = sectionSlotsFromSnapshot(snapshot)
+        val courses = coursesForWeek(snapshot, weekDates, sectionSlots)
+        val events = courses.mapNotNull { course ->
+            val dayIndex = weekDates.indexOfFirst { it.toString() == course.date }
+            if (dayIndex < 0) return@mapNotNull null
+            val start = sectionPositionByStartTime(course.start_time, sectionSlots)
+            val end = sectionPositionByEndTime(course.end_time, sectionSlots).coerceAtLeast(start + 0.78f)
+            val maxEnd = sectionSlots.size.toFloat() + 1f
+            val normalizedStart = start.coerceIn(1f, maxEnd - 0.1f)
+            val normalizedEnd = end.coerceIn(normalizedStart + 0.08f, maxEnd)
+            CourseEvent(
+                course = course,
+                dayIndex = dayIndex,
+                startPosition = normalizedStart,
+                slotSpan = (normalizedEnd - normalizedStart).coerceAtLeast(0.08f)
+            )
+        }
+
+        return WeekTimelineLayout(
+            snapshot = snapshot,
+            weekDates = weekDates,
+            sectionSlots = sectionSlots,
+            events = events,
+            columns = resolveColumns(events),
+            slotHeight = slotHeightForSectionCount(sectionSlots.size),
+            useCompactSlotText = sectionSlots.size > 9,
+            courseFontScale = snapshot.widgetCourseFontScale(),
+            primaryTextColor = Color.BLACK,
+            hintTextColor = ColorUtils.setAlphaComponent(Color.BLACK, 148),
+            dividerColor = ColorUtils.setAlphaComponent(Color.BLACK, 24)
+        )
+    }
+
+    private fun buildWeekDates(snapshot: WidgetSnapshot): List<LocalDate> {
+        val today = LocalDate.now()
+        val weekStart = startOfConfiguredWeek(today, snapshot.firstDayOfWeekValue())
+        return if (snapshot.show_weekends) {
+            (0..6).map { weekStart.plusDays(it.toLong()) }
+        } else {
+            (0..4).map { weekStart.plusDays(it.toLong()) }
+        }
+    }
+
+    private fun slotHeightForSectionCount(sectionCount: Int): Float {
+        return if (sectionCount > 9) MIN_SLOT_HEIGHT else DEFAULT_SLOT_HEIGHT
+    }
+
+    private fun sectionSlotsFromSnapshot(snapshot: WidgetSnapshot): List<SectionSlot> {
+        val slots = snapshot.time_slots
+            .filter { it.number > 0 && it.start_time.isNotBlank() }
+            .sortedBy { it.number }
+            .map { slot ->
+                SectionSlot(
+                    section = slot.number,
+                    start = slot.start_time.toShortTime(),
+                    end = slot.end_time.toShortTime()
+                )
+            }
+        return slots.ifEmpty { fallbackSectionSlots }
+    }
+
+    private fun coursesForWeek(
+        snapshot: WidgetSnapshot,
+        weekDates: List<LocalDate>,
+        slots: List<SectionSlot>
+    ): List<WidgetCourseProto> {
+        val validDates = weekDates.map { it.toString() }.toSet()
+        return snapshot.courses
+            .filter { it.date in validDates && !it.is_skipped }
+            .sortedWith(compareBy({ it.date }, { sectionPositionByStartTime(it.start_time, slots) }, { it.start_time }))
+    }
+
+    private fun drawWeekCoursesForSegment(
+        canvas: Canvas,
+        layout: WeekTimelineLayout,
+        segment: WeekTimelineSegment,
+        gridStart: Float,
+        dayWidth: Float,
+        timelineTop: Float,
+        timelineBottom: Float
+    ) {
+        val segmentStartBoundary = segment.startSlotIndex + 1f
+        val segmentEndBoundary = segment.endSlotIndex + 2f
+
+        layout.events.forEachIndexed { index, event ->
+            val visibleStart = max(event.startPosition, segmentStartBoundary)
+            val visibleEnd = min(event.endPosition, segmentEndBoundary)
+            if (visibleEnd - visibleStart <= 0.06f) return@forEachIndexed
+
+            val pair = layout.columns[event.identity] ?: (0 to 1)
+            val columnIndex = pair.first
+            val columnCount = pair.second
+            val outerGap = 2.5f
+            val innerGap = 2f
+            val availableWidth = dayWidth - outerGap * 2f
+            val cardWidth = if (columnCount <= 1) {
+                availableWidth
+            } else {
+                (availableWidth - innerGap * (columnCount - 1)) / columnCount
+            }
+            val left = gridStart + event.dayIndex * dayWidth + outerGap + columnIndex * (cardWidth + innerGap)
+            val top = timelineTop + (visibleStart - segmentStartBoundary) * layout.slotHeight + 2.4f
+            val maxHeight = timelineBottom - top - 2f
+            val height = min(max(layout.slotHeight * (visibleEnd - visibleStart) - 4.8f, 26f), maxHeight)
+            val color = courseColor(layout.snapshot, event.course.color_int, index)
+            drawCourseCard(canvas, left, top, cardWidth, height, event.course.displayText(), color, layout.primaryTextColor, layout.courseFontScale)
+        }
+    }
+
+    private fun drawEmptyWeekHint(
+        canvas: Canvas,
+        gridStart: Float,
+        gridWidth: Float,
+        timelineTop: Float,
+        timelineBottom: Float,
+        primaryText: Int,
+        hintText: Int
+    ) {
+        val centerX = gridStart + gridWidth / 2f
+        val centerY = (timelineTop + timelineBottom) / 2f
+        drawCenteredText(canvas, "本周暂无课程", centerX, centerY - 8f, 21f, primaryText, bold = true)
+        drawCenteredText(canvas, "继续下滑可查看后续节次", centerX, centerY + 20f, 14f, hintText)
+    }
+
+    private fun drawCourseCard(
+        canvas: Canvas,
+        left: Float,
+        top: Float,
+        width: Float,
+        height: Float,
+        text: String,
+        color: Int,
+        primaryText: Int,
+        fontScale: Float
+    ) {
+        val rect = RectF(left, top, left + width, top + height)
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = color
+            style = Paint.Style.FILL
+        }.also { paint ->
+            canvas.drawRoundRect(rect, 12f, 12f, paint)
+        }
+
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = ColorUtils.setAlphaComponent(Color.BLACK, 18)
+            style = Paint.Style.STROKE
+            strokeWidth = 1f
+        }.also { paint ->
+            canvas.drawRoundRect(rect, 12f, 12f, paint)
+        }
+
+        val textSize = 10.5f * fontScale
+        val lineHeight = 13.2f * fontScale
+        val firstBaseline = 17f * fontScale.coerceAtLeast(0.9f)
+        val horizontalInset = 6f
+        val saveCount = canvas.save()
+        canvas.clipRect(RectF(left + horizontalInset, top + 6f, left + width - horizontalInset, top + height - 6f))
+        val lines = text.replace(" @", "\n@").split('\n')
+            .flatMap { wrapText(it.trim(), width - horizontalInset * 2f, textSize, bold = true) }
+            .filter { it.isNotBlank() }
+        val maxLines = max(1, ((height - 10f) / lineHeight).toInt())
+        lines.take(maxLines).forEachIndexed { index, line ->
+            drawText(canvas, line, left + horizontalInset + 1f, top + firstBaseline + index * lineHeight, textSize, primaryText, bold = true)
+        }
+        canvas.restoreToCount(saveCount)
+    }
+
+    private fun resolveColumns(events: List<CourseEvent>): Map<String, Pair<Int, Int>> {
+        val result = mutableMapOf<String, Pair<Int, Int>>()
+        events.groupBy { it.dayIndex }.forEach { (_, dayEvents) ->
+            dayEvents.forEach { event ->
+                val overlaps = dayEvents.filter { it.overlaps(event) }
+                if (overlaps.size <= 1) {
+                    result[event.identity] = 0 to 1
+                    return@forEach
+                }
+                val ordered = overlaps.sortedWith(compareBy({ it.startPosition }, { it.course.id }, { it.course.name }))
+                ordered.forEachIndexed { index, overlap ->
+                    result[overlap.identity] = index to ordered.size
+                }
+            }
+        }
+        return result
+    }
+
+    private fun CourseEvent.overlaps(other: CourseEvent): Boolean {
+        return dayIndex == other.dayIndex && startPosition < other.endPosition && endPosition > other.startPosition
+    }
+
+    private fun sectionPositionByStartTime(timeText: String, slots: List<SectionSlot>): Float {
+        val time = parseTime(timeText) ?: return 1f
+        slots.forEachIndexed { index, slot ->
+            val start = parseTime(slot.start) ?: return@forEachIndexed
+            val end = parseTime(slot.end)
+            if (time.isBefore(start)) return index + 1f
+            if (end == null) {
+                if (!time.isBefore(start)) return index + 1f
+            } else if (!time.isBefore(start) && time <= end) {
+                val minutes = ChronoUnit.MINUTES.between(start, end).coerceAtLeast(1)
+                val offset = ChronoUnit.MINUTES.between(start, time).coerceAtLeast(0)
+                return index + 1f + (offset.toFloat() / minutes.toFloat()).coerceIn(0f, 0.95f)
+            }
+        }
+        return slots.size.toFloat() + 1f
+    }
+
+    private fun sectionPositionByEndTime(timeText: String, slots: List<SectionSlot>): Float {
+        val time = parseTime(timeText) ?: return 2f
+        slots.forEachIndexed { index, slot ->
+            val start = parseTime(slot.start) ?: return@forEachIndexed
+            val end = parseTime(slot.end)
+            if (time.isBefore(start)) return index + 1f
+            if (end == null) {
+                if (!time.isBefore(start)) return index + 2f
+            } else if (!time.isBefore(start) && time <= end) {
+                val minutes = ChronoUnit.MINUTES.between(start, end).coerceAtLeast(1)
+                val offset = ChronoUnit.MINUTES.between(start, time).coerceAtLeast(0)
+                return index + 1f + (offset.toFloat() / minutes.toFloat()).coerceIn(0.05f, 1f)
+            }
+        }
+        return slots.size.toFloat() + 1f
+    }
+
+    private fun String.toShortTime(): String {
+        return trim().takeIf { it.isNotBlank() }?.take(5).orEmpty()
+    }
+
+    private fun parseTime(timeText: String): LocalTime? {
+        val normalized = timeText.trim()
+        if (normalized.isBlank()) return null
+        return runCatching { LocalTime.parse(normalized) }.getOrNull()
+    }
+
+    private fun courseColor(snapshot: WidgetSnapshot, colorInt: Int, index: Int): Int {
+        val colorMaps = snapshot.style?.course_color_maps.orEmpty()
+        if (colorInt >= 0 && colorInt < colorMaps.size) {
+            return colorMaps[colorInt].light_color.toInt()
+        }
+        val fallback = intArrayOf(
+            Color.rgb(168, 205, 235),
+            Color.rgb(178, 217, 188),
+            Color.rgb(238, 207, 141),
+            Color.rgb(224, 184, 190),
+            Color.rgb(196, 188, 222)
+        )
+        return fallback[index % fallback.size]
+    }
+
+    private fun WidgetCourseProto.displayText(): String {
+        val location = position.trim()
+        return if (location.isBlank()) name else "$name @$location"
+    }
+
+    private fun drawText(
+        canvas: Canvas,
+        text: String,
+        x: Float,
+        baseline: Float,
+        size: Float,
+        color: Int,
+        bold: Boolean = false
+    ) {
+        val paint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = color
+            textSize = size
+            typeface = if (bold) android.graphics.Typeface.DEFAULT_BOLD else android.graphics.Typeface.DEFAULT
+        }
+        canvas.drawText(text, x, baseline, paint)
+    }
+
+    private fun drawCenteredText(
+        canvas: Canvas,
+        text: String,
+        centerX: Float,
+        baseline: Float,
+        size: Float,
+        color: Int,
+        bold: Boolean = false
+    ) {
+        val paint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = color
+            textSize = size
+            textAlign = Paint.Align.CENTER
+            typeface = if (bold) android.graphics.Typeface.DEFAULT_BOLD else android.graphics.Typeface.DEFAULT
+        }
+        canvas.drawText(text, centerX, baseline, paint)
+    }
+
+    private fun wrapText(text: String, maxWidth: Float, size: Float, bold: Boolean): List<String> {
+        val paint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = size
+            typeface = if (bold) android.graphics.Typeface.DEFAULT_BOLD else android.graphics.Typeface.DEFAULT
+        }
+        val result = mutableListOf<String>()
+        var current = ""
+        text.forEach { char ->
+            val next = current + char
+            if (paint.measureText(next) <= maxWidth || current.isEmpty()) {
+                current = next
+            } else {
+                result += current
+                current = char.toString()
+            }
+        }
+        if (current.isNotEmpty()) result += current
+        return result
+    }
+
+    private fun WeekTimelineSegment.coerceWithin(lastSlotIndex: Int): WeekTimelineSegment {
+        if (lastSlotIndex <= 0) return WeekTimelineSegment(0, 0)
+        val start = startSlotIndex.coerceIn(0, lastSlotIndex)
+        val end = endSlotIndex.coerceIn(start, lastSlotIndex)
+        return WeekTimelineSegment(start, end)
+    }
+
+    private data class SectionSlot(
+        val section: Int,
+        val start: String,
+        val end: String
+    )
+
+    private data class CourseEvent(
+        val course: WidgetCourseProto,
+        val dayIndex: Int,
+        val startPosition: Float,
+        val slotSpan: Float
+    ) {
+        val endPosition: Float = startPosition + slotSpan
+        val identity: String = "${course.id}_${course.date}_${course.start_time}_${course.name}"
+    }
+
+    private data class WeekTimelineLayout(
+        val snapshot: WidgetSnapshot,
+        val weekDates: List<LocalDate>,
+        val sectionSlots: List<SectionSlot>,
+        val events: List<CourseEvent>,
+        val columns: Map<String, Pair<Int, Int>>,
+        val slotHeight: Float,
+        val useCompactSlotText: Boolean,
+        val courseFontScale: Float,
+        val primaryTextColor: Int,
+        val hintTextColor: Int,
+        val dividerColor: Int
+    )
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineHeaderBinder.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineHeaderBinder.kt
@@ -1,0 +1,157 @@
+package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+import android.graphics.Color
+import android.view.View
+import android.widget.RemoteViews
+import androidx.core.graphics.ColorUtils
+import com.xingheyuzhuan.shiguangschedule.R
+import com.xingheyuzhuan.shiguangschedule.widget.WidgetSnapshot
+import com.xingheyuzhuan.shiguangschedule.widget.firstDayOfWeekValue
+import com.xingheyuzhuan.shiguangschedule.widget.startOfConfiguredWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object WeekTimelineHeaderBinder {
+    private val fullDayContainerIds = intArrayOf(
+        R.id.layout_week_timeline_day_0,
+        R.id.layout_week_timeline_day_1,
+        R.id.layout_week_timeline_day_2,
+        R.id.layout_week_timeline_day_3,
+        R.id.layout_week_timeline_day_4,
+        R.id.layout_week_timeline_day_5,
+        R.id.layout_week_timeline_day_6
+    )
+
+    private val fullDayLabelIds = intArrayOf(
+        R.id.tv_week_timeline_day_label_0,
+        R.id.tv_week_timeline_day_label_1,
+        R.id.tv_week_timeline_day_label_2,
+        R.id.tv_week_timeline_day_label_3,
+        R.id.tv_week_timeline_day_label_4,
+        R.id.tv_week_timeline_day_label_5,
+        R.id.tv_week_timeline_day_label_6
+    )
+
+    private val fullDayDateIds = intArrayOf(
+        R.id.tv_week_timeline_day_date_0,
+        R.id.tv_week_timeline_day_date_1,
+        R.id.tv_week_timeline_day_date_2,
+        R.id.tv_week_timeline_day_date_3,
+        R.id.tv_week_timeline_day_date_4,
+        R.id.tv_week_timeline_day_date_5,
+        R.id.tv_week_timeline_day_date_6
+    )
+
+    private val weekdayDayContainerIds = intArrayOf(
+        R.id.layout_week_timeline_weekday_day_0,
+        R.id.layout_week_timeline_weekday_day_1,
+        R.id.layout_week_timeline_weekday_day_2,
+        R.id.layout_week_timeline_weekday_day_3,
+        R.id.layout_week_timeline_weekday_day_4
+    )
+
+    private val weekdayDayLabelIds = intArrayOf(
+        R.id.tv_week_timeline_weekday_day_label_0,
+        R.id.tv_week_timeline_weekday_day_label_1,
+        R.id.tv_week_timeline_weekday_day_label_2,
+        R.id.tv_week_timeline_weekday_day_label_3,
+        R.id.tv_week_timeline_weekday_day_label_4
+    )
+
+    private val weekdayDayDateIds = intArrayOf(
+        R.id.tv_week_timeline_weekday_day_date_0,
+        R.id.tv_week_timeline_weekday_day_date_1,
+        R.id.tv_week_timeline_weekday_day_date_2,
+        R.id.tv_week_timeline_weekday_day_date_3,
+        R.id.tv_week_timeline_weekday_day_date_4
+    )
+
+    private val weekDaysFull = listOf("周一", "周二", "周三", "周四", "周五", "周六", "周日")
+    private val weekDaysShort = listOf("一", "二", "三", "四", "五", "六", "日")
+
+    fun bind(remoteViews: RemoteViews, snapshot: WidgetSnapshot) {
+        val today = LocalDate.now()
+        val weekStart = startOfConfiguredWeek(today, snapshot.firstDayOfWeekValue())
+        val weekDates = (0..6).map { weekStart.plusDays(it.toLong()) }
+        val primaryText = Color.BLACK
+        val secondaryText = ColorUtils.setAlphaComponent(Color.BLACK, 190)
+        val hintText = ColorUtils.setAlphaComponent(Color.BLACK, 148)
+
+        remoteViews.setTextViewText(
+            R.id.tv_week_timeline_date,
+            today.format(DateTimeFormatter.ofPattern("yyyy/M/d", Locale.getDefault()))
+        )
+        remoteViews.setTextViewText(R.id.tv_week_timeline_subtitle, buildSubtitle(snapshot, today))
+        remoteViews.setTextColor(R.id.tv_week_timeline_date, primaryText)
+        remoteViews.setTextColor(R.id.tv_week_timeline_subtitle, secondaryText)
+        remoteViews.setTextViewText(R.id.tv_week_timeline_month_number, today.monthValue.toString())
+        remoteViews.setTextColor(R.id.tv_week_timeline_month_number, primaryText)
+        remoteViews.setTextColor(R.id.tv_week_timeline_month_label, hintText)
+
+        if (snapshot.show_weekends) {
+            remoteViews.setViewVisibility(R.id.layout_week_timeline_days_container_full, View.VISIBLE)
+            remoteViews.setViewVisibility(R.id.layout_week_timeline_days_container_weekday, View.GONE)
+            bindDayRow(
+                remoteViews = remoteViews,
+                dates = weekDates,
+                containerIds = fullDayContainerIds,
+                labelIds = fullDayLabelIds,
+                dateIds = fullDayDateIds,
+                today = today,
+                primaryText = primaryText,
+                secondaryText = secondaryText,
+                hintText = hintText
+            )
+        } else {
+            remoteViews.setViewVisibility(R.id.layout_week_timeline_days_container_full, View.GONE)
+            remoteViews.setViewVisibility(R.id.layout_week_timeline_days_container_weekday, View.VISIBLE)
+            bindDayRow(
+                remoteViews = remoteViews,
+                dates = weekDates.take(5),
+                containerIds = weekdayDayContainerIds,
+                labelIds = weekdayDayLabelIds,
+                dateIds = weekdayDayDateIds,
+                today = today,
+                primaryText = primaryText,
+                secondaryText = secondaryText,
+                hintText = hintText
+            )
+        }
+    }
+
+    private fun bindDayRow(
+        remoteViews: RemoteViews,
+        dates: List<LocalDate>,
+        containerIds: IntArray,
+        labelIds: IntArray,
+        dateIds: IntArray,
+        today: LocalDate,
+        primaryText: Int,
+        secondaryText: Int,
+        hintText: Int
+    ) {
+        dates.forEachIndexed { index, date ->
+            val isSelected = date == today
+            remoteViews.setViewVisibility(containerIds[index], View.VISIBLE)
+            remoteViews.setTextViewText(labelIds[index], weekDaysShort[date.dayOfWeek.value - 1])
+            remoteViews.setTextViewText(dateIds[index], "${date.monthValue}/${date.dayOfMonth}")
+            remoteViews.setTextColor(labelIds[index], if (isSelected) primaryText else secondaryText)
+            remoteViews.setTextColor(dateIds[index], if (isSelected) primaryText else hintText)
+            remoteViews.setInt(
+                containerIds[index],
+                "setBackgroundResource",
+                if (isSelected) R.drawable.widget_week_timeline_day_selected else android.R.color.transparent
+            )
+        }
+    }
+
+    private fun buildSubtitle(snapshot: WidgetSnapshot, today: LocalDate): String {
+        val courseTableName = snapshot.course_table_name.ifBlank { "课表" }
+        val weekLabel = snapshot.current_week
+            .takeIf { it > 0 }
+            ?.let { "第${it}周" }
+            ?: "当前周"
+        return "$courseTableName | $weekLabel ${weekDaysFull[today.dayOfWeek.value - 1]}"
+    }
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineLayoutSlotStore.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineLayoutSlotStore.kt
@@ -1,0 +1,48 @@
+package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+import android.content.Context
+
+/**
+ * 记录周视图小组件当前使用的布局槽位。
+ *
+ * 周视图使用两个 ListView 布局交替刷新，避免部分桌面启动器缓存
+ * RemoteViewsService 数据导致刷新后仍显示旧内容。
+ */
+object WeekTimelineLayoutSlotStore {
+    private const val PREFS_NAME = "week_timeline_layout_slot_store"
+    private const val KEY_PREFIX = "layout_slot_"
+
+    @Synchronized
+    fun advance(context: Context, appWidgetId: Int): Int {
+        val prefs = prefs(context)
+        val current = prefs.getInt(key(appWidgetId), 0).normalize()
+        val next = 1 - current
+        prefs.edit().putInt(key(appWidgetId), next).apply()
+        return next
+    }
+
+    @Synchronized
+    fun current(context: Context, appWidgetId: Int): Int {
+        return prefs(context).getInt(key(appWidgetId), 0).normalize()
+    }
+
+    @Synchronized
+    fun remove(context: Context, appWidgetIds: IntArray) {
+        if (appWidgetIds.isEmpty()) return
+        prefs(context).edit().apply {
+            appWidgetIds.forEach { remove(key(it)) }
+        }.apply()
+    }
+
+    @Synchronized
+    fun clear(context: Context) {
+        prefs(context).edit().clear().apply()
+    }
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun key(appWidgetId: Int) = "$KEY_PREFIX$appWidgetId"
+
+    private fun Int.normalize(): Int = if (this == 1) 1 else 0
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineNativeProvider.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineNativeProvider.kt
@@ -1,0 +1,55 @@
+﻿package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.os.Bundle
+import com.xingheyuzhuan.shiguangschedule.widget.week_timeline.WeekTimelineLayoutSlotStore
+import com.xingheyuzhuan.shiguangschedule.widget.WorkManagerHelper
+import com.xingheyuzhuan.shiguangschedule.widget.updateAllWidgets
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+
+/**
+ * 周视图时间轴桌面小组件接收器
+ * 负责响应系统刷新广播并触发统一小组件刷新链路。
+ */
+class WeekTimelineNativeProvider : AppWidgetProvider() {
+    private val scope = MainScope()
+
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        scope.launch {
+            updateAllWidgets(context)
+        }
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle
+    ) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+        scope.launch {
+            updateAllWidgets(context)
+        }
+    }
+
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        super.onDeleted(context, appWidgetIds)
+        WeekTimelineLayoutSlotStore.remove(context, appWidgetIds)
+    }
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        WorkManagerHelper.schedulePeriodicWork(context)
+    }
+
+    override fun onDisabled(context: Context) {
+        super.onDisabled(context)
+        WeekTimelineLayoutSlotStore.clear(context)
+        WorkManagerHelper.cancelAllWork(context)
+    }
+}
+

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineNativeRenderer.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineNativeRenderer.kt
@@ -1,0 +1,91 @@
+﻿package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.SystemClock
+import android.widget.RemoteViews
+import com.xingheyuzhuan.shiguangschedule.MainActivity
+import com.xingheyuzhuan.shiguangschedule.R
+import com.xingheyuzhuan.shiguangschedule.widget.WidgetSnapshot
+
+object WeekTimelineNativeRenderer {
+    val collectionViewIds = intArrayOf(
+        R.id.lv_week_timeline_body_primary,
+        R.id.lv_week_timeline_body_secondary
+    )
+
+    fun render(
+        context: Context,
+        snapshot: WidgetSnapshot,
+        appWidgetId: Int,
+        renderToken: Long = SystemClock.elapsedRealtimeNanos(),
+        activeLayoutSlot: Int = (renderToken and 1L).toInt()
+    ): RemoteViews {
+        val activeIndex = activeLayoutSlot.coerceIn(0, collectionViewIds.lastIndex)
+        val activeCollectionId = collectionViewIds[activeIndex]
+        val layoutResId = if (activeIndex == 0) {
+            R.layout.widget_week_timeline_native
+        } else {
+            R.layout.widget_week_timeline_native_alt
+        }
+
+        val remoteViews = RemoteViews(context.packageName, layoutResId)
+        WeekTimelineHeaderBinder.bind(remoteViews, snapshot)
+
+        val clickPendingIntent = createLaunchPendingIntent(context, appWidgetId)
+        remoteViews.setOnClickPendingIntent(R.id.widget_root, clickPendingIntent)
+        remoteViews.setPendingIntentTemplate(activeCollectionId, clickPendingIntent)
+
+        val serviceIntent = createServiceIntent(
+            context = context,
+            snapshot = snapshot,
+            appWidgetId = appWidgetId,
+            renderToken = renderToken,
+            collectionSuffix = if (activeIndex == 0) "primary" else "secondary"
+        )
+        remoteViews.setRemoteAdapter(activeCollectionId, serviceIntent)
+        remoteViews.setEmptyView(activeCollectionId, R.id.tv_week_timeline_empty)
+        return remoteViews
+    }
+
+    private fun createServiceIntent(
+        context: Context,
+        snapshot: WidgetSnapshot,
+        appWidgetId: Int,
+        renderToken: Long,
+        collectionSuffix: String
+    ): Intent {
+        return Intent(context, WeekTimelineRemoteViewsService::class.java).apply {
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            val overrideScale = snapshot.style?.widget_course_font_scale
+            if (overrideScale != null && overrideScale > 0f) {
+                putExtra(WeekTimelineRemoteViewsService.EXTRA_WIDGET_FONT_SCALE, overrideScale)
+            }
+            data = Uri.parse(
+                toUri(Intent.URI_INTENT_SCHEME) +
+                    "#" + appWidgetId +
+                    "_" + collectionSuffix +
+                    "_" + (overrideScale ?: -1f) +
+                    "_" + snapshot.show_weekends +
+                    "_" + snapshot.first_day_of_week +
+                    "_" + snapshot.hashCode() +
+                    "_" + renderToken
+            )
+        }
+    }
+
+    private fun createLaunchPendingIntent(context: Context, appWidgetId: Int): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        return PendingIntent.getActivity(
+            context,
+            appWidgetId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineRemoteViewsService.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineRemoteViewsService.kt
@@ -1,0 +1,95 @@
+﻿package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.graphics.Bitmap
+import android.util.Log
+import android.widget.RemoteViews
+import android.widget.RemoteViewsService
+import com.xingheyuzhuan.shiguangschedule.R
+import com.xingheyuzhuan.shiguangschedule.widget.WidgetSnapshotLoader
+import kotlinx.coroutines.runBlocking
+
+class WeekTimelineRemoteViewsService : RemoteViewsService() {
+    override fun onGetViewFactory(intent: Intent): RemoteViewsFactory {
+        return WeekTimelineRemoteViewsFactory(applicationContext, intent)
+    }
+
+    companion object {
+        const val EXTRA_WIDGET_FONT_SCALE = "extra_widget_font_scale"
+    }
+}
+
+private class WeekTimelineRemoteViewsFactory(
+    private val context: android.content.Context,
+    intent: Intent
+) : RemoteViewsService.RemoteViewsFactory {
+
+    private val appWidgetId: Int = intent.getIntExtra(
+        AppWidgetManager.EXTRA_APPWIDGET_ID,
+        AppWidgetManager.INVALID_APPWIDGET_ID
+    )
+
+    private val widgetFontScaleOverride: Float? =
+        intent.getFloatExtra(WeekTimelineRemoteViewsService.EXTRA_WIDGET_FONT_SCALE, Float.NaN)
+            .takeUnless { it.isNaN() }
+
+    private var bodySegments: List<Bitmap> = emptyList()
+    private var dataVersion: Long = 0L
+
+    override fun onCreate() {
+        loadSnapshot()
+    }
+
+    override fun onDataSetChanged() {
+        loadSnapshot()
+    }
+
+    override fun onDestroy() {
+        bodySegments = emptyList()
+        dataVersion = 0L
+    }
+
+    override fun getCount(): Int {
+        return if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) 0 else bodySegments.size
+    }
+
+    override fun getViewAt(position: Int): RemoteViews? {
+        val bodyBitmap = bodySegments.getOrNull(position) ?: return null
+        return RemoteViews(context.packageName, R.layout.widget_week_timeline_body_item).apply {
+            setImageViewBitmap(R.id.iv_week_timeline_body, bodyBitmap)
+            setOnClickFillInIntent(R.id.widget_body_item_root, Intent())
+        }
+    }
+
+    override fun getLoadingView(): RemoteViews? = null
+
+    override fun getViewTypeCount(): Int = 1
+
+    override fun getItemId(position: Int): Long {
+        return (dataVersion shl 32) or (position.toLong() and 0xFFFFFFFFL)
+    }
+
+    override fun hasStableIds(): Boolean = false
+
+    private fun loadSnapshot() {
+        runBlocking {
+            runCatching {
+                val snapshot = WidgetSnapshotLoader.load(context, widgetFontScaleOverride)
+                val segments = WeekTimelineBodyRenderer.buildSegments(snapshot)
+                dataVersion = snapshot.hashCode().toLong() and 0xFFFFFFFFL
+                bodySegments = segments.map { segment ->
+                    WeekTimelineBodyRenderer.renderSegmentBitmap(snapshot, segment)
+                }
+                Log.d(
+                    "WeekTimelineRVService",
+                    "构建周课表分段：${segments.size}段, showWeekends=${snapshot.show_weekends}, dataVersion=$dataVersion"
+                )
+            }.onFailure { error ->
+                bodySegments = emptyList()
+                dataVersion = 0L
+                Log.e("WeekTimelineRVService", "加载桌面小组件周视图数据失败", error)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineSegment.kt
+++ b/app/src/main/java/com/xingheyuzhuan/shiguangschedule/widget/week_timeline/WeekTimelineSegment.kt
@@ -1,0 +1,30 @@
+﻿package com.xingheyuzhuan.shiguangschedule.widget.week_timeline
+
+internal data class WeekTimelineSegment(
+    val startSlotIndex: Int,
+    val endSlotIndex: Int
+) {
+    init {
+        require(startSlotIndex >= 0) { "startSlotIndex must be >= 0" }
+        require(endSlotIndex >= startSlotIndex) { "endSlotIndex must be >= startSlotIndex" }
+    }
+
+    val slotCount: Int get() = endSlotIndex - startSlotIndex + 1
+}
+
+internal fun buildWeekTimelineSegments(
+    totalSlots: Int,
+    fallbackTotalSlots: Int = 13
+): List<WeekTimelineSegment> {
+    val normalizedTotalSlots = if (totalSlots > 0) totalSlots else fallbackTotalSlots
+    if (normalizedTotalSlots <= 0) return emptyList()
+
+    val result = mutableListOf<WeekTimelineSegment>()
+    var start = 0
+    while (normalizedTotalSlots - start > 5) {
+        result += WeekTimelineSegment(startSlotIndex = start, endSlotIndex = start + 3)
+        start += 4
+    }
+    result += WeekTimelineSegment(startSlotIndex = start, endSlotIndex = normalizedTotalSlots - 1)
+    return result
+}

--- a/app/src/main/proto/schedule_style.proto
+++ b/app/src/main/proto/schedule_style.proto
@@ -62,6 +62,7 @@ message ScheduleGridStyleProto {
 
   // 字体配置
   optional float course_block_font_scale = 15; // 文字缩放比例 (默认 1.0)
+  optional float widget_course_font_scale = 28; // Desktop widget course text scale (default 1.0)
   optional bool hide_location = 16;       // 是否隐藏上课地点
   optional bool hide_teacher = 17;        // 是否隐藏授课老师
   optional bool remove_location_at = 18;  // 是否移除地点前的 @ 符号

--- a/app/src/main/proto/widget_snapshot.proto
+++ b/app/src/main/proto/widget_snapshot.proto
@@ -20,9 +20,19 @@ message WidgetCourseProto {
   string date = 9;
 }
 
+message WidgetTimeSlotProto {
+  int32 number = 1;
+  string start_time = 2;
+  string end_time = 3;
+}
+
 message WidgetSnapshot {
   repeated WidgetCourseProto courses = 1;
   int32 current_week = 2;
 
   .com.xingheyuzhuan.shiguangschedule.data.model.ScheduleGridStyleProto style = 3;
+  repeated WidgetTimeSlotProto time_slots = 4;
+  string course_table_name = 5;
+  bool show_weekends = 6;
+  int32 first_day_of_week = 7;
 }

--- a/app/src/main/res/drawable/widget_week_timeline_day_selected.xml
+++ b/app/src/main/res/drawable/widget_week_timeline_day_selected.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#18000000" />
+    <corners android:radius="14dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_week_timeline_weekbar_bg.xml
+++ b/app/src/main/res/drawable/widget_week_timeline_weekbar_bg.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#66FFFFFF" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/widget_week_timeline_body_item.xml
+++ b/app/src/main/res/layout/widget_week_timeline_body_item.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_body_item_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent">
+
+    <ImageView
+        android:id="@+id/iv_week_timeline_body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/widget_name_week_timeline"
+        android:scaleType="fitStart" />
+</FrameLayout>

--- a/app/src/main/res/layout/widget_week_timeline_native.xml
+++ b/app/src/main/res/layout/widget_week_timeline_native.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_bg_rounded"
+    android:orientation="vertical"
+    android:paddingStart="6dp"
+    android:paddingTop="6dp"
+    android:paddingEnd="6dp"
+    android:paddingBottom="6dp">
+
+    <TextView
+        android:id="@+id/tv_week_timeline_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/black"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/tv_week_timeline_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textColor="@android:color/black"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:id="@+id/layout_week_timeline_week_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/widget_week_timeline_weekbar_bg"
+        android:gravity="center_vertical"
+        android:minHeight="58dp"
+        android:orientation="horizontal"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
+
+        <LinearLayout
+            android:id="@+id/layout_week_timeline_month_column"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="64"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingStart="1dp"
+            android:paddingEnd="1dp">
+
+            <TextView
+                android:id="@+id/tv_week_timeline_month_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@android:color/black"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tv_week_timeline_month_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="1dp"
+                android:text="月"
+                android:textColor="@android:color/black"
+                android:textSize="10sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <FrameLayout
+            android:id="@+id/layout_week_timeline_days_host"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="497">
+
+            <LinearLayout
+                android:id="@+id/layout_week_timeline_days_container_full"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_0" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_1" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_2" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_3" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_4" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_5" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_5" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_5" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_6" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_6" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_6" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_week_timeline_days_container_weekday"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_0" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_1" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_2" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_3" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_4" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+            </LinearLayout>
+        </FrameLayout>
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/lv_week_timeline_body_primary"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_weight="1"
+        android:background="@android:color/transparent"
+        android:cacheColorHint="@android:color/transparent"
+        android:clipToPadding="false"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="0dp"
+        android:fadingEdgeLength="0dp"
+        android:fastScrollEnabled="false"
+        android:paddingBottom="2dp"
+        android:scrollbarStyle="outsideInset" />
+
+    <TextView
+        android:id="@+id/tv_week_timeline_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text=""
+        android:textColor="@android:color/black"
+        android:textSize="12sp"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/layout/widget_week_timeline_native_alt.xml
+++ b/app/src/main/res/layout/widget_week_timeline_native_alt.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_bg_rounded"
+    android:orientation="vertical"
+    android:paddingStart="6dp"
+    android:paddingTop="6dp"
+    android:paddingEnd="6dp"
+    android:paddingBottom="6dp">
+
+    <TextView
+        android:id="@+id/tv_week_timeline_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/black"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/tv_week_timeline_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textColor="@android:color/black"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:id="@+id/layout_week_timeline_week_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/widget_week_timeline_weekbar_bg"
+        android:gravity="center_vertical"
+        android:minHeight="58dp"
+        android:orientation="horizontal"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
+
+        <LinearLayout
+            android:id="@+id/layout_week_timeline_month_column"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="64"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingStart="1dp"
+            android:paddingEnd="1dp">
+
+            <TextView
+                android:id="@+id/tv_week_timeline_month_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@android:color/black"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tv_week_timeline_month_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="1dp"
+                android:text="月"
+                android:textColor="@android:color/black"
+                android:textSize="10sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <FrameLayout
+            android:id="@+id/layout_week_timeline_days_host"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="497">
+
+            <LinearLayout
+                android:id="@+id/layout_week_timeline_days_container_full"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_0" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_1" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_2" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_3" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_4" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_5" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_5" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_5" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_day_6" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_day_label_6" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_day_date_6" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_week_timeline_days_container_weekday"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_0" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_1" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_2" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_3" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+
+                <LinearLayout android:id="@+id/layout_week_timeline_weekday_day_4" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:gravity="center" android:orientation="vertical" android:paddingStart="1dp" android:paddingTop="5dp" android:paddingEnd="1dp" android:paddingBottom="5dp">
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_label_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textColor="@android:color/black" android:textSize="10sp" android:textStyle="bold" />
+                    <TextView android:id="@+id/tv_week_timeline_weekday_day_date_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginTop="1dp" android:textColor="@android:color/black" android:textSize="9sp" />
+                </LinearLayout>
+            </LinearLayout>
+        </FrameLayout>
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/lv_week_timeline_body_secondary"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_weight="1"
+        android:background="@android:color/transparent"
+        android:cacheColorHint="@android:color/transparent"
+        android:clipToPadding="false"
+        android:divider="@android:color/transparent"
+        android:dividerHeight="0dp"
+        android:fadingEdgeLength="0dp"
+        android:fastScrollEnabled="false"
+        android:paddingBottom="2dp"
+        android:scrollbarStyle="outsideInset" />
+
+    <TextView
+        android:id="@+id/tv_week_timeline_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text=""
+        android:textColor="@android:color/black"
+        android:textSize="12sp"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -122,6 +122,7 @@
     <string name="widget_name_tiny">Tiny 2x1</string>
     <string name="widget_name_compact">Compact 2x2</string>
     <string name="widget_name_double_days">Recent Days 4x2</string>
+    <string name="widget_name_week_timeline">Week timeline schedule 4x6</string>
     <string name="widget_name_list_vertical">Vertical Course List 4xN</string>
     <string name="widget_tomorrow_course_preview">Tomorrow</string>
     <string name="widget_no_courses_tomorrow">No courses tomorrow</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -122,6 +122,7 @@
     <string name="widget_name_tiny">超小课程2x1</string>
     <string name="widget_name_compact">紧凑课程2x2</string>
     <string name="widget_name_double_days">近日课程4x2</string>
+    <string name="widget_name_week_timeline">周视图课表4x6</string>
     <string name="widget_name_list_vertical">垂直列表课表4xN</string>
     <string name="widget_tomorrow_course_preview">明日预告</string>
     <string name="widget_no_courses_tomorrow">明天没有课程</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -122,6 +122,7 @@
     <string name="widget_name_tiny">超小課程2x1</string>
     <string name="widget_name_compact">緊湊課程2x2</string>
     <string name="widget_name_double_days">近日課程4x2</string>
+    <string name="widget_name_week_timeline">週視圖課表4x6</string>
     <string name="widget_name_list_vertical">垂直列表課表4xN</string>
     <string name="widget_tomorrow_course_preview">明日預告</string>
     <string name="widget_no_courses_tomorrow">明天沒有課程</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="widget_name_tiny">超小课程2x1</string>
     <string name="widget_name_compact">紧凑课程2x2</string>
     <string name="widget_name_double_days">近日课程4x2</string>
+    <string name="widget_name_week_timeline">周视图课表4x6</string>
     <string name="widget_name_list_vertical">垂直列表课表4xN</string>
     <string name="widget_tomorrow_course_preview">明日预告</string>
     <string name="widget_no_courses_tomorrow">明天没有课程</string>

--- a/app/src/main/res/xml/shiguangschedule_week_timeline_widget.xml
+++ b/app/src/main/res/xml/shiguangschedule_week_timeline_widget.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="320dp"
+    android:minResizeWidth="250dp"
+    android:minResizeHeight="260dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="6"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/widget_week_timeline_native"
+    android:previewImage="@drawable/widget_preview_list_vertical"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## 目标分支确认清单 (Target Branch Checklist)

### 本仓库已经开启main分支保护请不要提交pr到main

请在提交 PR 前，请完成以下表格：(方括号内填 "x" 以选中)
* [x] 代码已经经过实机测试
* [x] **确认目标分支是 `dev`。** (请勿直接合并到 `main` 或其他发布分支。)


## PR 描述 (Description)

新增一个「周视图课表 4x6」桌面小组件，用于在桌面直接查看当前周课程安排。

样例图片：
<img width="284" height="479" alt="shiguangschedule_2026-07-11_00-07-42" src="https://github.com/user-attachments/assets/f0002202-4ed9-4c41-8967-46e4511fa551" />


主要改动：

- 新增周视图课表桌面小组件入口。
- 支持按时间轴展示当前周课程。
- 支持显示课表名称、当前周次、日期栏和课程块。
- 支持根据课表配置显示工作日或包含周末。
- 支持读取课表时间段，并按实际时间渲染课程位置。
- 支持同一时间段多课程重叠时分列显示。
- 接入现有桌面小组件刷新流程。
- 扩展小组件快照数据，补充时间段、课表名称、周末显示和每周起始日信息。

测试情况：

- [x] 已运行 `.\gradlew.bat :app:compileDevDebugKotlin --stacktrace`
- [x] 编译通过
- [x] 已进行实机测试，小组件可正常添加和使用